### PR TITLE
Replaces parseData.fromCSV with parseData.load

### DIFF
--- a/area/index.js
+++ b/area/index.js
@@ -11,7 +11,7 @@ import * as areaChart from './areaChart.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%d/%m/%y';
+const dateFormat = '%d/%m/%y';
 /*
   some common formatting parsers....
   '%m/%d/%Y'        01/28/1986
@@ -74,20 +74,20 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
         .margin({ top: 40, left: 7, bottom: 35, right: 7 })
     // .title("Put headline here")
-        //.width(53.71)// 1 col 
-        .width(112.25)// 2 col 
+        //.width(53.71)// 1 col
+        .width(112.25)// 2 col
         //.width(170.8)// 3 col
         //.width(229.34)// 4 col
-        //.width(287.88)// 5 col 
+        //.width(287.88)// 5 col
         //.width(346.43)// 6 col
-        //.width(74)// markets std print 
+        //.width(74)// markets std print
         .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
         .margin({ top: 140, left: 50, bottom: 138, right: 40 })
     // .title("Put headline here")
         .width(612)
-        .height(612), 
+        .height(612),
 
     video: gChartframe.videoFrame(sharedConfig)
         .margin({ left: 207, right: 207, bottom: 210, top: 233 }),
@@ -103,7 +103,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, dateStructure).then((data) => {
+parseData.load(dataFile, { dateFormat }).then((data) => {
     // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
     const seriesNames = parseData.getSeriesNames(data.columns);
 

--- a/area/parseData.js
+++ b/area/parseData.js
@@ -3,26 +3,24 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, dateStructure) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                // make sure all the dates in the date column are a date object
-                const parseDate = d3.timeParse(dateStructure);
-                data.forEach((d) => {
-                    d.date = parseDate(d.date);
-                });
-
-                resolve(data);
-            }
+export function load(url, options) { // eslint-disable-line
+    const { dateFormat } = options;
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        // make sure all the dates in the date column are a date object
+        const parseDate = d3.timeParse(dateFormat);
+        data.forEach((d) => {
+            d.date = parseDate(d.date);
         });
+
+        return data;
     });
 }
 

--- a/bar-stacked-german-election/index.js
+++ b/bar-stacked-german-election/index.js
@@ -62,7 +62,7 @@ const frame = {
         //Print column sizes-- 1col 53.71mm: 2col 112.25mm: 3col 170.8mm: 4col 229.34mm: 5col 287.88mm: 6col 346.43,
         .width(112.25)
         .height(69.85),
-        
+
 
     social: gChartframe.socialFrame(sharedConfig)
         .margin({ top: 140, left: 50, bottom: 138, right: 40 })
@@ -84,7 +84,8 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, { sort }).then(({ valueExtent, plotData, seriesNames }) => {
+parseData.load(dataFile, { sort })
+.then(({ valueExtent, plotData, seriesNames }) => {
     Object.keys(frame).forEach((frameName) => {
         const currentFrame = frame[frameName];
         const partyColours = d3.scaleOrdinal()
@@ -141,7 +142,7 @@ parseData.fromCSV(dataFile, { sort }).then(({ valueExtent, plotData, seriesNames
         currentFrame.plot()
             .call(myXAxis);
 
-        
+
         if (xAxisAlign === 'top') {
             myXAxis.xLabel().attr('transform', `translate(0,${myXAxis.tickSize()})`);
         }

--- a/bar-stacked-german-election/parseData.js
+++ b/bar-stacked-german-election/parseData.js
@@ -3,84 +3,81 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const { sort } = options;
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { sort } = options;
 
-                const seriesNames = getSeriesNames(data.columns);
+        const seriesNames = getSeriesNames(data.columns);
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
 
-                // function that calculates the position of each rectangle in the stack
-                const getStacks = function getStacks(el) {
-                    let posCumulative = 0;
-                    let negCumulative = 0;
-                    let baseX = 0;
-                    let baseX1 = 0;
-                    const stacks = seriesNames.map((name, i) => {
-                        if (el[name] > 0) {
-                            baseX1 = posCumulative;
-                            posCumulative += (+el[name]);
-                            baseX = posCumulative;
-                        }
-                        if (el[name] < 0) {
-                            baseX1 = negCumulative;
-                            negCumulative += (+el[name]);
-                            baseX = negCumulative;
-                            if (i < 1) { baseX = 0; baseX1 = negCumulative; }
-                        }
-                        return {
-                            name,
-                            x: +baseX,
-                            x1: +baseX1,
-                            value: +el[name],
-                        };
-                    });
-                    return stacks;
-                };
-
-                const plotData = data.map(d => ({
-                    name: d.name,
-                    bands: getStacks(d),
-                    total: d3.sum(getStacks(d), stack => stack.value),
-                }));
-
-                switch (sort) {
-                case 'descending':
-                    plotData.sort((a, b) => b.total - a.total);// Sorts biggest rects to the left
-                    break;
-                case 'ascending':
-                    plotData.sort((a, b) => a.total - b.total);// Sorts biggest rects to the right
-                    break;
-
-                case 'alphabetical':
-                    plotData.sort((a, b) => a.name.localeCompare(b.name));
-                    break;
-                default:
-                    break;
+        // function that calculates the position of each rectangle in the stack
+        const getStacks = function getStacks(el) {
+            let posCumulative = 0;
+            let negCumulative = 0;
+            let baseX = 0;
+            let baseX1 = 0;
+            const stacks = seriesNames.map((name, i) => {
+                if (el[name] > 0) {
+                    baseX1 = posCumulative;
+                    posCumulative += (+el[name]);
+                    baseX = posCumulative;
                 }
+                if (el[name] < 0) {
+                    baseX1 = negCumulative;
+                    negCumulative += (+el[name]);
+                    baseX = negCumulative;
+                    if (i < 1) { baseX = 0; baseX1 = negCumulative; }
+                }
+                return {
+                    name,
+                    x: +baseX,
+                    x1: +baseX1,
+                    value: +el[name],
+                };
+            });
+            return stacks;
+        };
 
-                const columnNames = data.map(d => d.name); // create an array of the column names
+        const plotData = data.map(d => ({
+            name: d.name,
+            bands: getStacks(d),
+            total: d3.sum(getStacks(d), stack => stack.value),
+        }));
 
-                resolve({
-                    valueExtent,
-                    columnNames,
-                    seriesNames,
-                    plotData,
-                    data,
-                });
-            }
-        });
+        switch (sort) {
+        case 'descending':
+            plotData.sort((a, b) => b.total - a.total);// Sorts biggest rects to the left
+            break;
+        case 'ascending':
+            plotData.sort((a, b) => a.total - b.total);// Sorts biggest rects to the right
+            break;
+
+        case 'alphabetical':
+            plotData.sort((a, b) => a.name.localeCompare(b.name));
+            break;
+        default:
+            break;
+        }
+
+        const columnNames = data.map(d => d.name); // create an array of the column names
+
+        return {
+            valueExtent,
+            columnNames,
+            seriesNames,
+            plotData,
+            data,
+        };
     });
 }
 

--- a/bar-stacked/index.js
+++ b/bar-stacked/index.js
@@ -50,13 +50,13 @@ const frame = {
         .margin({ top: 40, left: 7, bottom: 35, right: 7 })
     // .title("Put headline here")
         /* Print column widths */
-        //.width(53.71)// 1 col 
-        .width(112.25)// 2 col 
+        //.width(53.71)// 1 col
+        .width(112.25)// 2 col
         //.width(170.8)// 3 col
         //.width(229.34)// 4 col
-        //.width(287.88)// 5 col 
+        //.width(287.88)// 5 col
         //.width(346.43)// 6 col
-        //.width(74)// markets std print 
+        //.width(74)// markets std print
         .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -79,8 +79,8 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, { sort }).then(({ valueExtent, plotData, seriesNames }) => {
-   
+parseData.load(dataFile, { sort })
+.then(({ valueExtent, plotData, seriesNames }) => {
     Object.keys(frame).forEach((frameName) => {
         const currentFrame = frame[frameName];
 

--- a/bar-stacked/parseData.js
+++ b/bar-stacked/parseData.js
@@ -3,84 +3,81 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const { sort } = options;
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { sort } = options;
 
-                const seriesNames = getSeriesNames(data.columns);
+        const seriesNames = getSeriesNames(data.columns);
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
 
-                // function that calculates the position of each rectangle in the stack
-                const getStacks = function getStacks(el) {
-                    let posCumulative = 0;
-                    let negCumulative = 0;
-                    let baseX = 0;
-                    let baseX1 = 0;
-                    const stacks = seriesNames.map((name, i) => {
-                        if (el[name] > 0) {
-                            baseX1 = posCumulative;
-                            posCumulative += (+el[name]);
-                            baseX = posCumulative;
-                        }
-                        if (el[name] < 0) {
-                            baseX1 = negCumulative;
-                            negCumulative += (+el[name]);
-                            baseX = negCumulative;
-                            if (i < 1) { baseX = 0; baseX1 = negCumulative; }
-                        }
-                        return {
-                            name,
-                            x: +baseX,
-                            x1: +baseX1,
-                            value: +el[name],
-                        };
-                    });
-                    return stacks;
-                };
-
-                const plotData = data.map(d => ({
-                    name: d.name,
-                    bands: getStacks(d),
-                    total: d3.sum(getStacks(d), stack => stack.value),
-                }));
-
-                switch (sort) {
-                case 'descending':
-                    plotData.sort((a, b) => b.total - a.total);// Sorts biggest rects to the left
-                    break;
-                case 'ascending':
-                    plotData.sort((a, b) => a.total - b.total);// Sorts biggest rects to the right
-                    break;
-
-                case 'alphabetical':
-                    plotData.sort((a, b) => a.name.localeCompare(b.name));
-                    break;
-                default:
-                    break;
+        // function that calculates the position of each rectangle in the stack
+        const getStacks = function getStacks(el) {
+            let posCumulative = 0;
+            let negCumulative = 0;
+            let baseX = 0;
+            let baseX1 = 0;
+            const stacks = seriesNames.map((name, i) => {
+                if (el[name] > 0) {
+                    baseX1 = posCumulative;
+                    posCumulative += (+el[name]);
+                    baseX = posCumulative;
                 }
+                if (el[name] < 0) {
+                    baseX1 = negCumulative;
+                    negCumulative += (+el[name]);
+                    baseX = negCumulative;
+                    if (i < 1) { baseX = 0; baseX1 = negCumulative; }
+                }
+                return {
+                    name,
+                    x: +baseX,
+                    x1: +baseX1,
+                    value: +el[name],
+                };
+            });
+            return stacks;
+        };
 
-                const columnNames = data.map(d => d.name); // create an array of the column names
+        const plotData = data.map(d => ({
+            name: d.name,
+            bands: getStacks(d),
+            total: d3.sum(getStacks(d), stack => stack.value),
+        }));
 
-                resolve({
-                    valueExtent,
-                    columnNames,
-                    seriesNames,
-                    plotData,
-                    data,
-                });
-            }
-        });
+        switch (sort) {
+        case 'descending':
+            plotData.sort((a, b) => b.total - a.total);// Sorts biggest rects to the left
+            break;
+        case 'ascending':
+            plotData.sort((a, b) => a.total - b.total);// Sorts biggest rects to the right
+            break;
+
+        case 'alphabetical':
+            plotData.sort((a, b) => a.name.localeCompare(b.name));
+            break;
+        default:
+            break;
+        }
+
+        const columnNames = data.map(d => d.name); // create an array of the column names
+
+        return {
+            valueExtent,
+            columnNames,
+            seriesNames,
+            plotData,
+            data,
+        };
     });
 }
 

--- a/bar/index.js
+++ b/bar/index.js
@@ -55,13 +55,13 @@ const frame = {
    .margin({ top: 40, left: 7, bottom: 35, right: 7 })
    // .title("Put headline here")
    /* Print column widths */
-    //.width(53.71)// 1 col 
-    .width(112.25)// 2 col 
+    //.width(53.71)// 1 col
+    .width(112.25)// 2 col
     //.width(170.8)// 3 col
     //.width(229.34)// 4 col
-    //.width(287.88)// 5 col 
+    //.width(287.88)// 5 col
     //.width(346.43)// 6 col
-    //.width(74)// markets std print 
+    //.width(74)// markets std print
     .height(58.21),//markets std print
 
 
@@ -85,7 +85,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, { sort, sortOn })
+parseData.load(dataFile, { sort, sortOn })
 .then(({ seriesNames, plotData, valueExtent, data }) => {
     // Draw the frames
     Object.keys(frame).forEach((frameName) => {

--- a/bar/parseData.js
+++ b/bar/parseData.js
@@ -3,45 +3,42 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const { sort, sortOn } = options;
-                // automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
-                const groupNames = data.map(d => d.name).filter(d => d); // create an array of the group names
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
-                // Buid the dataset for plotting
-                const plotData = data.map(d => ({
-                    name: d.name,
-                    groups: getGroups(seriesNames, d),
-                }));
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { sort, sortOn } = options;
+        // automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
+        const groupNames = data.map(d => d.name).filter(d => d); // create an array of the group names
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
+        // Buid the dataset for plotting
+        const plotData = data.map(d => ({
+            name: d.name,
+            groups: getGroups(seriesNames, d),
+        }));
 
-                if (sort === 'descending') {
-                    plotData.sort((a, b) =>
-                        b.groups[sortOn].value - a.groups[sortOn].value);// Sorts biggest rects to the left
-                } else if (sort === 'ascending') {
-                    plotData.sort((a, b) => a.groups[sortOn].value - b.groups[sortOn].value);
-                } // Sorts biggest rects to the left
+        if (sort === 'descending') {
+            plotData.sort((a, b) =>
+                b.groups[sortOn].value - a.groups[sortOn].value);// Sorts biggest rects to the left
+        } else if (sort === 'ascending') {
+            plotData.sort((a, b) => a.groups[sortOn].value - b.groups[sortOn].value);
+        } // Sorts biggest rects to the left
 
-                resolve({
-                    groupNames,
-                    valueExtent,
-                    seriesNames,
-                    plotData,
-                    data,
-                });
-            }
-        });
+        return {
+            groupNames,
+            valueExtent,
+            seriesNames,
+            plotData,
+            data,
+        };
     });
 }
 

--- a/choropleth/index.js
+++ b/choropleth/index.js
@@ -94,7 +94,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile).then((data) => {
+parseData.load(dataFile).then((data) => {
     // define chart
     const colorScale = d3.scaleOrdinal()
         .domain(partyScale.range())

--- a/choropleth/parseData.js
+++ b/choropleth/parseData.js
@@ -3,30 +3,28 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                // automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
+        // automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
 
-                resolve({
-                    seriesNames,
-                    valueExtent,
-                    data,
-                });
-            }
-        });
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
+
+        return {
+            seriesNames,
+            valueExtent,
+            data,
+        };
     });
 }
 

--- a/circle-timeline/index.js
+++ b/circle-timeline/index.js
@@ -7,7 +7,7 @@ import * as circleTimeline from './circleTimeline.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%Y';
+const dateFormat = '%Y';
 const circleSize = 1;
 /*
   some common formatting parsers....
@@ -88,7 +88,8 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, dateStructure).then(({ valueExtent, seriesNames, plotData, dateDomain }) => {
+parseData.load(dataFile, { dateFormat })
+.then(({ valueExtent, seriesNames, plotData, dateDomain }) => {
     // make sure all the dates in the date column are a date object
     // var parseDate = d3.timeParse("%d/%m/%Y")
     // data.forEach(function(d) {
@@ -147,7 +148,7 @@ parseData.fromCSV(dataFile, dateStructure).then(({ valueExtent, seriesNames, plo
             .rScale(rScale)
             .maxCircle(maxCircle)
             .xScale(myXAxis.scale())
-            .setDateFormat(dateStructure);
+            .setDateFormat(dateFormat);
 
         currentFrame.plot()
             .selectAll('.timelineHolder')

--- a/column-grouped/index.js
+++ b/column-grouped/index.js
@@ -51,13 +51,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
     .margin({ top: 40, left: 7, bottom: 35, right: 7 })
     //.title("Put headline here")
-    //.width(53.71)// 1 col 
-    .width(112.25)// 2 col 
+    //.width(53.71)// 1 col
+    .width(112.25)// 2 col
     //.width(170.8)// 3 col
     //.width(229.34)// 4 col
-    //.width(287.88)// 5 col 
+    //.width(287.88)// 5 col
     //.width(346.43)// 6 col
-    //.width(74)// markets std print 
+    //.width(74)// markets std print
     .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -80,7 +80,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, { sort, sortOn })
+parseData.load(dataFile, '', { sort, sortOn })
 .then(({ seriesNames, plotData, valueExtent, data }) => {
 
     // define chart

--- a/column-grouped/parseData.js
+++ b/column-grouped/parseData.js
@@ -3,49 +3,46 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const { sort, sortOn } = options;
-                const seriesNames = getSeriesNames(data.columns);
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { sort, sortOn } = options;
+        const seriesNames = getSeriesNames(data.columns);
 
-                const groupNames = data.map(d => d.name).filter(d => d); // create an array of the group names
+        const groupNames = data.map(d => d.name).filter(d => d); // create an array of the group names
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
 
-                // Buid the dataset for plotting
-                const plotData = data.map(d => ({
-                    name: d.name,
-                    groups: getGroups(seriesNames, d),
-                }));
+        // Buid the dataset for plotting
+        const plotData = data.map(d => ({
+            name: d.name,
+            groups: getGroups(seriesNames, d),
+        }));
 
-                if (sort === 'descending') {
-                    plotData.sort((a, b) =>
-                        b.groups[sortOn].value - a.groups[sortOn].value);// Sorts biggest rects to the left
-                } else if (sort === 'ascending') {
-                    plotData.sort((a, b) => a.groups[sortOn].value - b.groups[sortOn].value);
-                } // Sorts biggest rects to the left
-                else if (sort === 'alphabetical') {
-                    plotData.sort((a, b) => a.name.localeCompare(b.name))
-                } // Sorts alphabetically
+        if (sort === 'descending') {
+            plotData.sort((a, b) =>
+                b.groups[sortOn].value - a.groups[sortOn].value);// Sorts biggest rects to the left
+        } else if (sort === 'ascending') {
+            plotData.sort((a, b) => a.groups[sortOn].value - b.groups[sortOn].value);
+        } // Sorts biggest rects to the left
+        else if (sort === 'alphabetical') {
+            plotData.sort((a, b) => a.name.localeCompare(b.name))
+        } // Sorts alphabetically
 
-                resolve({
-                    valueExtent,
-                    seriesNames,
-                    plotData,
-                    data,
-                });
-            }
-        });
+        return {
+            valueExtent,
+            seriesNames,
+            plotData,
+            data,
+        };
     });
 }
 

--- a/column-stacked/index.js
+++ b/column-stacked/index.js
@@ -49,13 +49,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
         .margin({ top: 40, left: 7, bottom: 35, right: 7 })
     // .title("Put headline here")
-        //.width(53.71)// 1 col 
-        .width(112.25)// 2 col 
+        //.width(53.71)// 1 col
+        .width(112.25)// 2 col
         //.width(170.8)// 3 col
         //.width(229.34)// 4 col
-        //.width(287.88)// 5 col 
+        //.width(287.88)// 5 col
         //.width(346.43)// 6 col
-        //.width(74)// markets std print 
+        //.width(74)// markets std print
         .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -78,8 +78,9 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, { sort }).then(({ valueExtent, seriesNames, plotData }) => {
-    
+parseData.load(dataFile, '', { sort })
+.then(({ valueExtent, seriesNames, plotData }) => {
+
     // define chart
     const myChart = stackedColumnChart.draw() // eslint-disable-line
         .seriesNames(seriesNames)

--- a/column-stacked/parseData.js
+++ b/column-stacked/parseData.js
@@ -3,83 +3,80 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const { sort } = options;
-                const seriesNames = getSeriesNames(data.columns);
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { sort } = options;
+        const seriesNames = getSeriesNames(data.columns);
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
 
-                // function that calculates the position of each rectangle in the stack
-                const getStacks = function getStacks(el) {
-                    let posCumulative = 0;
-                    let negCumulative = 0;
-                    let baseY = 0;
-                    let baseY1 = 0;
-                    const stacks = seriesNames.map((name, i) => {
-                        if (el[name] > 0) {
-                            baseY1 = posCumulative;
-                            posCumulative += (+el[name]);
-                            baseY = posCumulative;
-                        }
-                        if (el[name] < 0) {
-                            baseY1 = negCumulative;
-                            negCumulative += (+el[name]);
-                            baseY = negCumulative;
-                            if (i < 1) { baseY = 0; baseY1 = negCumulative; }
-                        }
-                        return {
-                            name,
-                            y: +baseY,
-                            y1: +baseY1,
-                            value: +el[name],
-                        };
-                    });
-                    return stacks;
-                };
-
-                const plotData = data.map(d => ({
-                    name: d.name,
-                    bands: getStacks(d),
-                    total: d3.sum(getStacks(d), stack => stack.value),
-                }));
-
-                switch (sort) {
-                case 'descending':
-                    plotData.sort((a, b) => b.total - a.total);// Sorts biggest rects to the left
-                    break;
-                case 'ascending':
-                    plotData.sort((a, b) => a.total - b.total);// Sorts biggest rects to the right
-                    break;
-
-                case 'alphabetical':
-                    plotData.sort((a, b) => a.name.localeCompare(b.name));
-                    break;
-                default:
-                    break;
+        // function that calculates the position of each rectangle in the stack
+        const getStacks = function getStacks(el) {
+            let posCumulative = 0;
+            let negCumulative = 0;
+            let baseY = 0;
+            let baseY1 = 0;
+            const stacks = seriesNames.map((name, i) => {
+                if (el[name] > 0) {
+                    baseY1 = posCumulative;
+                    posCumulative += (+el[name]);
+                    baseY = posCumulative;
                 }
+                if (el[name] < 0) {
+                    baseY1 = negCumulative;
+                    negCumulative += (+el[name]);
+                    baseY = negCumulative;
+                    if (i < 1) { baseY = 0; baseY1 = negCumulative; }
+                }
+                return {
+                    name,
+                    y: +baseY,
+                    y1: +baseY1,
+                    value: +el[name],
+                };
+            });
+            return stacks;
+        };
 
-                const columnNames = data.map(d => d.name); // create an array of the column names
+        const plotData = data.map(d => ({
+            name: d.name,
+            bands: getStacks(d),
+            total: d3.sum(getStacks(d), stack => stack.value),
+        }));
 
-                resolve({
-                    valueExtent,
-                    columnNames,
-                    seriesNames,
-                    plotData,
-                    data,
-                });
-            }
-        });
+        switch (sort) {
+        case 'descending':
+            plotData.sort((a, b) => b.total - a.total);// Sorts biggest rects to the left
+            break;
+        case 'ascending':
+            plotData.sort((a, b) => a.total - b.total);// Sorts biggest rects to the right
+            break;
+
+        case 'alphabetical':
+            plotData.sort((a, b) => a.name.localeCompare(b.name));
+            break;
+        default:
+            break;
+        }
+
+        const columnNames = data.map(d => d.name); // create an array of the column names
+
+        return {
+            valueExtent,
+            columnNames,
+            seriesNames,
+            plotData,
+            data,
+        };
     });
 }
 

--- a/column-timeline/index.js
+++ b/column-timeline/index.js
@@ -7,7 +7,7 @@ import * as parseData from './parseData.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%d-%b-%y';
+const dateFormat = '%d-%b-%y';
 /*
   some common formatting parsers....
   '%m/%d/%Y'        01/28/1986
@@ -94,7 +94,8 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, dateStructure).then(({ columnNames, seriesNames, valueExtent, plotData, data, highlights }) => {
+parseData.load(dataFile, { dateFormat })
+.then(({ columnNames, seriesNames, valueExtent, plotData, data, highlights }) => {
     // define chart
     const myChart = columnTimelineChart.draw()
           .seriesNames(seriesNames)

--- a/dotplot/index.js
+++ b/dotplot/index.js
@@ -55,13 +55,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
    .margin({ top: 40, left: 7, bottom: 35, right: 7 })
     //.title("Put headline here")
-    //.width(53.71)// 1 col 
-    .width(112.25)// 2 col 
+    //.width(53.71)// 1 col
+    .width(112.25)// 2 col
     //.width(170.8)// 3 col
     //.width(229.34)// 4 col
-    //.width(287.88)// 5 col 
+    //.width(287.88)// 5 col
     //.width(346.43)// 6 col
-    //.width(74)// markets std print 
+    //.width(74)// markets std print
     .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -84,7 +84,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataURL, { sort, sortOn })
+parseData.load(dataURL, { sort, sortOn })
 .then(({ groupNames, plotData, valueExtent, data }) => {
     // Draw the frames
     Object.keys(frame).forEach((frameName) => {
@@ -157,7 +157,7 @@ parseData.fromCSV(dataURL, { sort, sortOn })
             .rem(currentFrame.rem())
             .lines(lines)
             .frameName(frameName);
-        
+
         myQuartiles
             // .paddingInner(0.06)
             .colourProperty(colourProperty)
@@ -194,10 +194,10 @@ parseData.fromCSV(dataURL, { sort, sortOn })
             .append('g')
             .attr('class', 'dotholder baseline')
             .call(myChart);
-        
-        //Ensure that the linking lines are not drawn a second time 
+
+        //Ensure that the linking lines are not drawn a second time
         myChart.lines(false)
-        
+
         //Then draw highlighted circles so that they are on top
         currentFrame.plot()
             .selectAll('.dotHighlight')

--- a/hemicycle/index.js
+++ b/hemicycle/index.js
@@ -16,18 +16,7 @@ const sharedConfig = {
     source: 'Source not yet added',
 };
 
-const parties = {
-    llamas: '#ff0000',
-    avocados: '#00ff00',
-    ducks: '#0000ff',
-};
-
-const partyOrder = {
-    llamas: 1,
-    ducks: 2,
-    avocados: 3,
-    empty: 99,
-};
+const partyOrder = {};
 
 // Individual frame configuratiuon, used to set margins (defaults shown below) etc
 const frame = {
@@ -76,7 +65,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile).then(({ data, plotData, seriesNames }) => {
+parseData.load(dataFile).then(({ data, plotData, seriesNames }) => {
     // define chart
     const myChart = hemicycle.draw()
         .datasize(data.reduce((col, d) => col + Number(d.seats), 0));

--- a/hemicycle/parseData.js
+++ b/hemicycle/parseData.js
@@ -3,30 +3,27 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = d3.extent(data, d => d.seats);
-                // const plotData = data.map(d => d3.range(d.seats).map(() => d));
-                const plotData = data.map(d => (d.seats = Number(d.seats), d)); // eslint-disable-line
-                const seriesNames = d3.map(data, d => d.party).keys();
-                resolve({
-                    valueExtent,
-                    plotData,
-                    data,
-                    seriesNames,
-                });
-            }
-        });
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = d3.extent(data, d => d.seats);
+        // const plotData = data.map(d => d3.range(d.seats).map(() => d));
+        const plotData = data.map(d => (d.seats = Number(d.seats), d)); // eslint-disable-line
+        const seriesNames = d3.map(data, d => d.party).keys();
+        return {
+            valueExtent,
+            plotData,
+            data,
+            seriesNames,
+        };
     });
 }
 

--- a/line-dual-axis/index.js
+++ b/line-dual-axis/index.js
@@ -11,7 +11,7 @@ import * as lineChart from './lineChart.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%d/%m/%Y';
+const dateFormat = '%d/%m/%Y';
 /*
   some common formatting parsers....
   '%m/%d/%Y'        01/28/1986
@@ -76,13 +76,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
  .margin({ top: 40, left: 7, bottom: 35, right: 12 })
   // .title("Put headline here")
-  //.width(53.71)// 1 col 
-  .width(112.25)// 2 col 
+  //.width(53.71)// 1 col
+  .width(112.25)// 2 col
   //.width(170.8)// 3 col
   //.width(229.34)// 4 col
-  //.width(287.88)// 5 col 
+  //.width(287.88)// 5 col
   //.width(346.43)// 6 col
-  //.width(74)// markets std print 
+  //.width(74)// markets std print
   .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -105,7 +105,7 @@ d3.selectAll('.framed')
           .call(frame[figure.node().dataset.frame]);
   });
 
-parseData.fromCSV(dataFile, dateStructure).then((data) => {
+parseData.load(dataFile, { dateFormat }).then((data) => {
     // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
     const seriesNames = parseData.getSeriesNames(data.columns);
 

--- a/line-dual-axis/parseData.js
+++ b/line-dual-axis/parseData.js
@@ -3,26 +3,25 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, dateStructure) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                // make sure all the dates in the date column are a date object
-                const parseDate = d3.timeParse(dateStructure);
-                data.forEach((d) => {
-                    d.date = parseDate(d.date);
-                });
+export function load(url, options) { // eslint-disable-line
+    const { dateFormat } = options;
 
-                resolve(data);
-            }
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        // make sure all the dates in the date column are a date object
+        const parseDate = d3.timeParse(dateFormat);
+        data.forEach((d) => {
+            d.date = parseDate(d.date);
         });
+
+        return data;
     });
 }
 
@@ -81,10 +80,10 @@ export function getlines(d, group, index) {
         column.highlight = el.highlight
         column.annotate = el.annotate
         if(el[group]) {
-            lineData.push(column)  
+            lineData.push(column)
         }
         if(el[group] == false) {
-            lineData.push(null)  
+            lineData.push(null)
         }
 
     });

--- a/line/index.js
+++ b/line/index.js
@@ -11,7 +11,7 @@ import * as lineChart from './lineChart.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%d/%m/%Y';
+const dateFormat = '%d/%m/%Y';
 /*
   some common formatting parsers....
   '%m/%d/%Y'        01/28/1986
@@ -105,8 +105,8 @@ d3.selectAll('.framed')
       figure.select('svg')
           .call(frame[figure.node().dataset.frame]);
   });
-parseData.fromCSV(dataFile, dateStructure, { yMin, joinPoints, highlightNames }).then(({seriesNames, data, plotData, valueExtent, highlights, annos}) => {
-
+parseData.load(dataFile, { dateFormat, yMin, joinPoints, highlightNames })
+.then(({ seriesNames, data, plotData, valueExtent, highlights, annos }) => {
     Object.keys(frame).forEach((frameName) => {
         const currentFrame = frame[frameName];
 

--- a/line/parseData.js
+++ b/line/parseData.js
@@ -3,70 +3,67 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, dateStructure, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const {yMin, joinPoints, highlightNames } = options;
-                // make sure all the dates in the date column are a date object
-                const parseDate = d3.timeParse(dateStructure);
-                data.forEach((d) => {
-                    d.date = parseDate(d.date);
-                });
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { yMin, joinPoints, highlightNames, dateFormat } = options;
+        // make sure all the dates in the date column are a date object
+        const parseDate = d3.timeParse(dateFormat);
+        data.forEach((d) => {
+            d.date = parseDate(d.date);
+        });
 
-                // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
+        // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames, yMin);
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames, yMin);
 
-                // Format the dataset that is used to draw the lines
-                const plotData = seriesNames.map(d => ({
-                    name: d,
-                    lineData: getlines(data, d),
-                }));
+        // Format the dataset that is used to draw the lines
+        const plotData = seriesNames.map(d => ({
+            name: d,
+            lineData: getlines(data, d),
+        }));
 
-                // Sort the data so that the labeled items are drawn on top
-                const dataSorter = function dataSorter(a, b) {
-                    if (highlightNames.indexOf(a.name) > highlightNames.indexOf(b.name)) {
-                        return 1;
-                    } else if (highlightNames.indexOf(a.name) === highlightNames.indexOf(b.name)) {
-                        return 0;
-                    }
-                    return -1;
-                };
-                if (highlightNames.length > 0) { plotData.sort(dataSorter); }
+        // Sort the data so that the labeled items are drawn on top
+        const dataSorter = function dataSorter(a, b) {
+            if (highlightNames.indexOf(a.name) > highlightNames.indexOf(b.name)) {
+                return 1;
+            } else if (highlightNames.indexOf(a.name) === highlightNames.indexOf(b.name)) {
+                return 0;
+            }
+            return -1;
+        };
+        if (highlightNames.length > 0) { plotData.sort(dataSorter); }
 
-                 // Filter data for annotations
-                const annos = data.filter(d => (d.annotate !== '' && d.annotate !== undefined));
+         // Filter data for annotations
+        const annos = data.filter(d => (d.annotate !== '' && d.annotate !== undefined));
 
-                // Format the data that is used to draw highlight tonal bands
-                const boundaries = data.filter(d => (d.highlight === 'begin' || d.highlight === 'end'));
-                const highlights = [];
+        // Format the data that is used to draw highlight tonal bands
+        const boundaries = data.filter(d => (d.highlight === 'begin' || d.highlight === 'end'));
+        const highlights = [];
 
-                boundaries.forEach((d, i) => {
-                    if (d.highlight === 'begin') {
-                        highlights.push({ begin: d.date, end: boundaries[i + 1].date });
-                    }
-                });
-
-                resolve({
-                    seriesNames,
-                    plotData,
-                    data,
-                    valueExtent,
-                    highlights,
-                    annos
-                });
+        boundaries.forEach((d, i) => {
+            if (d.highlight === 'begin') {
+                highlights.push({ begin: d.date, end: boundaries[i + 1].date });
             }
         });
+
+        return {
+            seriesNames,
+            plotData,
+            data,
+            valueExtent,
+            highlights,
+            annos
+        };
     });
 }
 
@@ -129,10 +126,10 @@ export function getlines(d, group, joinPoints) {
         }
 
         // if(el[group] == false) {
-        //     lineData.push(null)  
+        //     lineData.push(null)
         // }
         if(el[group] == false && joinPoints == false) {
-            lineData.push(null)  
+            lineData.push(null)
         }
 
     });

--- a/lollipop-v/index.js
+++ b/lollipop-v/index.js
@@ -8,7 +8,7 @@ import * as gAxis from 'g-axis';
 import * as parseData from './parseData.js';
 import * as lollipopChart from './lollipopChart.js';
 
-const dataURL = "data.csv"
+const dataURL = 'data.csv';
 
 const sharedConfig = {
     title: 'Title not yet added',
@@ -70,13 +70,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
     .margin({ top: 40, left: 7, bottom: 35, right: 7 })
     // .title("Put headline here")
-    //.width(53.71)// 1 col 
-    .width(112.25)// 2 col 
+    //.width(53.71)// 1 col
+    .width(112.25)// 2 col
     //.width(170.8)// 3 col
     //.width(229.34)// 4 col
-    //.width(287.88)// 5 col 
+    //.width(287.88)// 5 col
     //.width(346.43)// 6 col
-    //.width(74)// markets std print 
+    //.width(74)// markets std print
     .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -98,7 +98,8 @@ d3.selectAll('.framed')
         figure.select('svg').call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataURL).then(({ seriesNames, valueExtent, data }) => {
+parseData.load(dataURL)
+.then(({ seriesNames, valueExtent, data }) => {
     // set up axes
     const myYAxis = gAxis.yLinear();
     const myXAxis = gAxis.xOrdinal();

--- a/lollipop-v/parseData.js
+++ b/lollipop-v/parseData.js
@@ -3,30 +3,27 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                // automatically calculate the seriesnames excluding the reserved "name" and "group" fields
-                const seriesNames = getSeriesNames(data.columns);
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        // automatically calculate the seriesnames excluding the reserved "name" and "group" fields
+        const seriesNames = getSeriesNames(data.columns);
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
 
-                resolve({
-                    seriesNames,
-                    valueExtent,
-                    data,
-                });
-            }
-        });
+        return {
+            seriesNames,
+            valueExtent,
+            data,
+        };
     });
 }
 

--- a/pie-chart/index.js
+++ b/pie-chart/index.js
@@ -8,7 +8,7 @@ import gChartframe from 'g-chartframe';
 import * as parseData from './parseData.js';
 import * as pieChart from './pieChart.js';
 
-const dataURL="data.csv"
+const dataURL = 'data.csv';
 
 const sharedConfig = {
     title: 'Title not yet added',
@@ -48,13 +48,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
    .margin({ top: 40, left: 20, bottom: 35, right: 20 })
     // .title("Put headline here")
- 	  //.width(53.71)// 1 col 
-    .width(112.25)// 2 col 
+ 	  //.width(53.71)// 1 col
+    .width(112.25)// 2 col
     //.width(170.8)// 3 col
     //.width(229.34)// 4 col
-    //.width(287.88)// 5 col 
+    //.width(287.88)// 5 col
     //.width(346.43)// 6 col
-    //.width(74)// markets std print 
+    //.width(74)// markets std print
     .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -77,9 +77,8 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataURL).then(({ seriesNames, data }) => {
+parseData.load(dataURL).then(({ seriesNames, data }) => {
     // Use the seriesNames array to calculate the minimum and max values in the dataset
-
 
     const valueFormat = d => d3.format(',')(d);
     const pie = d3.pie()
@@ -88,7 +87,7 @@ parseData.fromCSV(dataURL).then(({ seriesNames, data }) => {
 
     // define chart
     const myChart = pieChart.draw()
-              .seriesNames(seriesNames)
+              .seriesNames(seriesNames);
           // .plotDim(currentFrame.dimension())
           // .rem(currentFrame.rem())
           // .colourPalette((frameName));
@@ -114,9 +113,6 @@ parseData.fromCSV(dataURL).then(({ seriesNames, data }) => {
               .attr('class', 'arc')
               .attr('transform', `translate(${currentFrame.dimension().width / 2},${currentFrame.dimension().height / 2} )`)
           .call(myChart);
-
-
-          
     });
     // addSVGSavers('figure.saveable');
 });

--- a/pie-chart/parseData.js
+++ b/pie-chart/parseData.js
@@ -2,31 +2,24 @@
  * General data munging functionality
  */
 
-import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-        
-                // automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
 
-                function hasGroupName(element, index, array) {
-                  return element !== '';
-                }
-                resolve({
-                    seriesNames,
-                    data,
-                });
-            }
-        });
+        // automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
+
+        return {
+            seriesNames,
+            data,
+        };
     });
 }
 

--- a/scatter/index.js
+++ b/scatter/index.js
@@ -74,13 +74,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
         .margin({ top: 40, left: 7, bottom: 35, right: 17 })
     // .title("Put headline here")
-        //.width(53.71)// 1 col 
-        .width(112.25)// 2 col 
+        //.width(53.71)// 1 col
+        .width(112.25)// 2 col
         //.width(170.8)// 3 col
         //.width(229.34)// 4 col
-        //.width(287.88)// 5 col 
+        //.width(287.88)// 5 col
         //.width(346.43)// 6 col
-        //.width(74)// markets std print 
+        //.width(74)// markets std print
         .height(58.21),//markets std print
 
 
@@ -103,8 +103,8 @@ d3.selectAll('.framed')
         figure.select('svg').call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataURL).then(({ seriesNames, valueExtent, data }) => { // eslint-disable-line
-// identify groups
+parseData.load(dataURL).then(({ seriesNames, valueExtent, data }) => { // eslint-disable-line
+    // identify groups
     const groups = d3.map(data, d => d.group).keys();
 
     // determin extents for each scale

--- a/scatter/parseData.js
+++ b/scatter/parseData.js
@@ -3,30 +3,28 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                // automatically calculate the seriesnames excluding the reserved "name" and "group" fields
-                const seriesNames = getSeriesNames(data.columns);
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
+        // automatically calculate the seriesnames excluding the reserved "name" and "group" fields
+        const seriesNames = getSeriesNames(data.columns);
 
-                resolve({
-                    seriesNames,
-                    valueExtent,
-                    data,
-                });
-            }
-        });
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
+
+        return {
+            seriesNames,
+            valueExtent,
+            data,
+        };
     });
 }
 

--- a/slope/index.js
+++ b/slope/index.js
@@ -83,7 +83,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataURL).then(({ seriesNames, setColourPalette, groupNames, dataSorter, data }) => {
+parseData.load(dataURL).then(({ seriesNames, setColourPalette, groupNames, dataSorter, data }) => {
     // Use the seriesNames array to calculate the minimum and max values in the dataset
     const valueExtent = parseData.extentMulti(data, seriesNames);
     data.sort(dataSorter);

--- a/slope/parseData.js
+++ b/slope/parseData.js
@@ -3,48 +3,44 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
+export function load(url, options) { // eslint-disable-line
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
 
-                // automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
+        // automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
 
-                const groupNames = data.map(d => d.group).filter(d => d); // create an array of the group names
+        const groupNames = data.map(d => d.group).filter(d => d); // create an array of the group names
 
-                const dataSorter = (a, b) => {    // Sort the data so that the labeled items are drawn on top
-                    if (groupNames.indexOf(a.group) > groupNames.indexOf(b.group)) {
-                        return 1;
-                    } else if (groupNames.indexOf(a.group) === groupNames.indexOf(b.group)) {
-                        return 0;
-                    }
-                    return -1;
-                };
-
-                function hasGroupName(element, index, array) {
-                  return element !== '';
-                }
-
-                const setColourPalette = data.map(d => d.group).every(hasGroupName);
-
-
-                resolve({
-                    seriesNames,
-                    setColourPalette,
-                    groupNames,
-                    dataSorter,
-                    data,
-                });
+        const dataSorter = (a, b) => {    // Sort the data so that the labeled items are drawn on top
+            if (groupNames.indexOf(a.group) > groupNames.indexOf(b.group)) {
+                return 1;
+            } else if (groupNames.indexOf(a.group) === groupNames.indexOf(b.group)) {
+                return 0;
             }
-        });
+            return -1;
+        };
+
+        function hasGroupName(element) {
+            return element !== '';
+        }
+
+        const setColourPalette = data.map(d => d.group).every(hasGroupName);
+
+        return {
+            seriesNames,
+            setColourPalette,
+            groupNames,
+            dataSorter,
+            data,
+        };
     });
 }
 

--- a/small-multiple-bar/index.js
+++ b/small-multiple-bar/index.js
@@ -11,7 +11,7 @@ import * as barChart from './smallMultiBarChart.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%d/%m/%Y';
+const dateFormat = '%d/%m/%Y';
 /*
   some common formatting parsers....
   '%m/%d/%Y'        01/28/1986
@@ -123,7 +123,8 @@ d3.selectAll('.framed')
         figure.select('svg')
             .call(frame[figure.node().dataset.frame]);
     });
-parseData.fromCSV(dataFile, dateStructure, { xMin, dataDivisor }).then(({ data, plotData, valueExtent }) => {
+parseData.load(dataFile, { dateFormat, xMin, dataDivisor })
+.then(({ data, plotData, valueExtent }) => {
     Object.keys(frame).forEach((frameName) => {
         const currentFrame = frame[frameName];
 

--- a/small-multiple-bar/parseData.js
+++ b/small-multiple-bar/parseData.js
@@ -3,62 +3,61 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, dateStructure, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const { xMin, dataDivisor } = options;
-                // make sure all the dates in the date column are a date object
-                const parseDate = d3.timeParse(dateStructure);
-                data.forEach((d) => {
-                    d.date = parseDate(d.date);
-                });
+export function load(url, options) {
+    const { dateFormat } = options;
 
-                // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { xMin, dataDivisor } = options;
+        // make sure all the dates in the date column are a date object
+        const parseDate = d3.timeParse(dateFormat);
+        data.forEach((d) => {
+            d.date = parseDate(d.date);
+        });
 
-                const columnNames = data.map(d => d.date); // create an array of the column names
+        // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames, xMin);
+        const columnNames = data.map(d => d.date); // create an array of the column names
 
-                 // Filter data for annotations
-                const annos = data.filter(d => (d.annotate !== '' && d.annotate !== undefined));
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames, xMin);
 
-                // Format the data that is used to draw highlight tonal bands
-                const boundaries = data.filter(d => (d.highlight === 'begin' || d.highlight === 'end'));
-                const highlights = [];
+         // Filter data for annotations
+        const annos = data.filter(d => (d.annotate !== '' && d.annotate !== undefined));
 
-                boundaries.forEach((d, i) => {
-                    if (d.highlight === 'begin') {
-                        highlights.push({ begin: d.date, end: boundaries[i + 1].date });
-                    }
-                });
+        // Format the data that is used to draw highlight tonal bands
+        const boundaries = data.filter(d => (d.highlight === 'begin' || d.highlight === 'end'));
+        const highlights = [];
 
-                // format the dataset that is used to draw the lines
-                const plotData = seriesNames.map(d => ({
-                    name: d,
-                    columnData: getColumns(data, d, dataDivisor),
-                }));
-
-                resolve({
-                    columnNames,
-                    seriesNames,
-                    plotData,
-                    data,
-                    valueExtent,
-                    highlights,
-                    annos,
-                });
+        boundaries.forEach((d, i) => {
+            if (d.highlight === 'begin') {
+                highlights.push({ begin: d.date, end: boundaries[i + 1].date });
             }
         });
+
+        // format the dataset that is used to draw the lines
+        const plotData = seriesNames.map(d => ({
+            name: d,
+            columnData: getColumns(data, d, dataDivisor),
+        }));
+
+        return {
+            columnNames,
+            seriesNames,
+            plotData,
+            data,
+            valueExtent,
+            highlights,
+            annos,
+        };
     });
 }
 

--- a/small-multiple-column-timeline/index.js
+++ b/small-multiple-column-timeline/index.js
@@ -11,7 +11,7 @@ import * as columnChart from './smallMultiColumnTimeChart.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%d/%m/%Y';
+const dateFormat = '%d/%m/%Y';
 /*
   some common formatting parsers....
   '%m/%d/%Y'        01/28/1986
@@ -112,7 +112,8 @@ d3.selectAll('.framed')
       figure.select('svg')
           .call(frame[figure.node().dataset.frame]);
   });
-parseData.fromCSV(dataFile, dateStructure, { yMin, dataDivisor }).then(({ seriesNames, columnNames, data, plotData, valueExtent, highlights, annos }) => {
+parseData.load(dataFile, { dateFormat, yMin, dataDivisor })
+.then(({ seriesNames, columnNames, data, plotData, valueExtent, highlights, annos }) => {
     Object.keys(frame).forEach((frameName) => {
         const currentFrame = frame[frameName];
 

--- a/small-multiple-line/index.js
+++ b/small-multiple-line/index.js
@@ -11,7 +11,7 @@ import * as lineChart from './smallMultiLineChart.js';
 
 const dataFile = 'data.csv';
 
-const dateStructure = '%d/%m/%Y';
+const dateFormat = '%d/%m/%Y';
 /*
   some common formatting parsers....
   '%m/%d/%Y'        01/28/1986
@@ -117,7 +117,8 @@ d3.selectAll('.framed')
       figure.select('svg')
           .call(frame[figure.node().dataset.frame]);
   });
-parseData.fromCSV(dataFile, dateStructure, { yMin, joinPoints, dataDivisor }).then(({ seriesNames, data, plotData, valueExtent, highlights, annos }) => {
+parseData.load(dataFile, { dateFormat, yMin, joinPoints, dataDivisor })
+.then(({ seriesNames, data, plotData, valueExtent, highlights, annos }) => {
     Object.keys(frame).forEach((frameName) => {
         const currentFrame = frame[frameName];
 

--- a/small-multiple-line/parseData.js
+++ b/small-multiple-line/parseData.js
@@ -3,60 +3,59 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, dateStructure, options) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                const { yMin, joinPoints, dataDivisor } = options;
-                // make sure all the dates in the date column are a date object
-                const parseDate = d3.timeParse(dateStructure);
-                data.forEach((d) => {
-                    d.date = parseDate(d.date);
-                });
+export function load(url, options) { // eslint-disable-line
+    const { dateFormat } = options;
 
-                // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
+        const { yMin, joinPoints, dataDivisor } = options;
+        // make sure all the dates in the date column are a date object
+        const parseDate = d3.timeParse(dateFormat);
+        data.forEach((d) => {
+            d.date = parseDate(d.date);
+        });
+
+        // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
 
 
-                // Format the dataset that is used to draw the lines
-                const plotData = seriesNames.map(d => ({
-                    name: d,
-                    lineData: getlines(data, d, joinPoints, dataDivisor),
-                }));
+        // Format the dataset that is used to draw the lines
+        const plotData = seriesNames.map(d => ({
+            name: d,
+            lineData: getlines(data, d, joinPoints, dataDivisor),
+        }));
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames, yMin);
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames, yMin);
 
-                 // Filter data for annotations
-                const annos = data.filter(d => (d.annotate !== '' && d.annotate !== undefined));
+         // Filter data for annotations
+        const annos = data.filter(d => (d.annotate !== '' && d.annotate !== undefined));
 
-                // Format the data that is used to draw highlight tonal bands
-                const boundaries = data.filter(d => (d.highlight === 'begin' || d.highlight === 'end'));
-                const highlights = [];
+        // Format the data that is used to draw highlight tonal bands
+        const boundaries = data.filter(d => (d.highlight === 'begin' || d.highlight === 'end'));
+        const highlights = [];
 
-                boundaries.forEach((d, i) => {
-                    if (d.highlight === 'begin') {
-                        highlights.push({ begin: d.date, end: boundaries[i + 1].date });
-                    }
-                });
-
-                resolve({
-                    seriesNames,
-                    plotData,
-                    data,
-                    valueExtent,
-                    highlights,
-                    annos,
-                });
+        boundaries.forEach((d, i) => {
+            if (d.highlight === 'begin') {
+                highlights.push({ begin: d.date, end: boundaries[i + 1].date });
             }
         });
+
+        return {
+            seriesNames,
+            plotData,
+            data,
+            valueExtent,
+            highlights,
+            annos,
+        };
     });
 }
 

--- a/wrapper-starter/index.js
+++ b/wrapper-starter/index.js
@@ -4,7 +4,7 @@ import * as CHANGETHISTOYOURCHARTNAME from './chartNameHere.js';
 import * as parseData from './parseData.js';
 
 // User defined constants similar to version 2
-const dateStructure = '%d/%m/%Y';
+const dateFormat = '%d/%m/%Y';
 
 const dataFile = 'data.csv';
 
@@ -48,13 +48,13 @@ const frame = {
     print: gChartframe.printFrame(sharedConfig)
     .margin({ top: 40, left: 7, bottom: 35, right: 7 })
     // .title("Put headline here")
-    //.width(53.71)// 1 col 
-    .width(112.25)// 2 col 
+    //.width(53.71)// 1 col
+    .width(112.25)// 2 col
     //.width(170.8)// 3 col
     //.width(229.34)// 4 col
-    //.width(287.88)// 5 col 
+    //.width(287.88)// 5 col
     //.width(346.43)// 6 col
-    //.width(74)// markets std print 
+    //.width(74)// markets std print
     .height(58.21),//markets std print
 
     social: gChartframe.socialFrame(sharedConfig)
@@ -75,7 +75,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, dateStructure).then((data) => {
+parseData.load(dataFile, { dateFormat }).then((data) => {
     // define chart
     const myChart = CHANGETHISTOYOURCHARTNAME.draw() // eslint-disable-line
         .seriesNames(data.seriesNames);

--- a/wrapper-starter/parseData.js
+++ b/wrapper-starter/parseData.js
@@ -3,37 +3,37 @@
  */
 
 import * as d3 from 'd3';
+import loadData from '@financial-times/load-data';
 
 /**
- * Parses CSV file and returns structured data
- * @param  {String} url Path to CSV file
+ * Parses data file and returns structured data
+ * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function fromCSV(url, dateFormat) {
-    return new Promise((resolve, reject) => {
-        d3.csv(url, (error, data) => {
-            if (error) reject(error);
-            else {
-                // make sure all the dates in the date column are a date object
-                const parseDate = d3.timeParse(dateFormat);
+export function load(url, options) {
+    const { dateFormat } = options;
 
-                data.forEach((d) => {
-                    d.date = parseDate(d.date);
-                });
+    return loadData(url).then((result) => {
+        const data = result.data ? result.data : result;
 
-                // automatically calculate the seriesnames excluding the "marker" and "annotate column"
-                const seriesNames = getSeriesNames(data.columns);
+        // make sure all the dates in the date column are a date object
+        const parseDate = d3.timeParse(dateFormat);
 
-                // Use the seriesNames array to calculate the minimum and max values in the dataset
-                const valueExtent = extentMulti(data, seriesNames);
-
-                resolve({
-                    seriesNames,
-                    valueExtent,
-                    data,
-                });
-            }
+        data.forEach((d) => {
+            d.date = parseDate(d.date);
         });
+
+        // automatically calculate the seriesnames excluding the "marker" and "annotate column"
+        const seriesNames = getSeriesNames(data.columns);
+
+        // Use the seriesNames array to calculate the minimum and max values in the dataset
+        const valueExtent = extentMulti(data, seriesNames);
+
+        return {
+            seriesNames,
+            valueExtent,
+            data,
+        };
     });
 }
 


### PR DESCRIPTION
I've done a few things here, with the intent of enabling multiple file formats to be used for data as well as improve API consistency:

a. I've renamed "dateStructure" to "dateFormat" as that's more idiomatic
b. I've replaced `fromCSV()` in `*/parseData.js` with `load()`, which takes one or more URLs and an options object. `dateFormat` is now always an option passed with this object, which improves API consistency.

N.b., going through everything, there is a *lot* of linting that needs to be done. I've held off this PR so my commits are more readable, but I want to do a serious batch of linting after this gets merged.