### PR TITLE
Replaces Metric with MetricWeb

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -5,7 +5,7 @@
 .section-heading {
     background-color: #00757F;
     color: #fff;
-    font-family: Metric;
+    font-family: MetricWeb;
     font-weight: 600;
     font-size: 20px;
     padding: 8px 8px 5px;
@@ -32,7 +32,7 @@ svg {
 .ft-webgraphic-m .axis text,
 .ft-webgraphic-m-default .axis text,
 .ft-webgraphic-l .axis text {
-  font-family: Metric;
+  font-family: MetricWeb;
   fill: #66605C;
 }
 
@@ -73,18 +73,18 @@ svg {
 
 .ft-printgraphic .axis text,
 .ft-printgraphic .highlighted-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 9.6px;
     fill: #000000;
 }
 .ft-socialgraphic .axis text,
 .ft-socialgraphic .highlighted-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 28px;
 }
 .ft-videographic .axis text,
 .ft-videographic .highlighted-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 48px;
 }
 
@@ -374,7 +374,7 @@ svg {
 .ft-webgraphic-m .timeline-label,
 .ft-webgraphic-m-default .timeline-label,
 .ft-webgraphic-l .timeline-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     fill: #000000;
 }
 
@@ -383,7 +383,7 @@ svg {
 .ft-webgraphic-m .legend,
 .ft-webgraphic-m-default .legend,
 .ft-webgraphic-l .legend {
-    font-family: Metric;
+    font-family: MetricWeb;
     fill: #66605C;
 }
 
@@ -409,14 +409,14 @@ svg {
 
 .ft-printgraphic .timeline-label,
 .ft-printgraphic .legend {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 9.6px;
     fill: #000000;
 }
 
 .ft-socialgraphic .timeline-label,
 .ft-socialgraphic .legend text {
-    font-family: Metric;
+    font-family: MetricWeb;
     opacity: 0.5;
     fill: #FFFFFF;
     font-size: 28px;
@@ -424,7 +424,7 @@ svg {
 
 .ft-videographic .timeline-label,
 .ft-videographic .legend text{
-    font-family: Metric;
+    font-family: MetricWeb;
     opacity: 0.5;
     fill: #FFFFFF;
     font-size: 48px;
@@ -448,7 +448,7 @@ ul {
     border-radius: 10px;
     background-color: #00757F;
     color: #fff;
-    font-family: Metric;
+    font-family: MetricWeb;
     font-weight: 600;
     font-size: 20px;
     height: 25px;

--- a/styles.css
+++ b/styles.css
@@ -5,7 +5,7 @@
 .section-heading {
     background-color: #00757F;
     color: #fff;
-    font-family: Metric;
+    font-family: MetricWeb;
     font-weight: 600;
     font-size: 20px;
     padding: 8px 8px 5px;
@@ -32,7 +32,7 @@ svg {
 .ft-webgraphic-m .axis text,
 .ft-webgraphic-m-default .axis text,
 .ft-webgraphic-l .axis text {
-  font-family: Metric;
+  font-family: MetricWeb;
   fill: #66605C;
 }
 
@@ -73,18 +73,18 @@ svg {
 
 .ft-printgraphic .axis text,
 .ft-printgraphic .highlighted-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 9.6px;
     fill: #000000;
 }
 .ft-socialgraphic .axis text,
 .ft-socialgraphic .highlighted-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 28px;
 }
 .ft-videographic .axis text,
 .ft-videographic .highlighted-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 48px;
 }
 
@@ -374,7 +374,7 @@ svg {
 .ft-webgraphic-m .timeline-label,
 .ft-webgraphic-m-default .timeline-label,
 .ft-webgraphic-l .timeline-label {
-    font-family: Metric;
+    font-family: MetricWeb;
     fill: #000000;
 }
 
@@ -383,7 +383,7 @@ svg {
 .ft-webgraphic-m .legend,
 .ft-webgraphic-m-default .legend,
 .ft-webgraphic-l .legend {
-    font-family: Metric;
+    font-family: MetricWeb;
     fill: #66605C;
 }
 
@@ -409,14 +409,14 @@ svg {
 
 .ft-printgraphic .timeline-label,
 .ft-printgraphic .legend {
-    font-family: Metric;
+    font-family: MetricWeb;
     font-size: 9.6px;
     fill: #000000;
 }
 
 .ft-socialgraphic .timeline-label,
 .ft-socialgraphic .legend text {
-    font-family: Metric;
+    font-family: MetricWeb;
     opacity: 0.5;
     fill: #FFFFFF;
     font-size: 28px;
@@ -424,7 +424,7 @@ svg {
 
 .ft-videographic .timeline-label,
 .ft-videographic .legend text{
-    font-family: Metric;
+    font-family: MetricWeb;
     opacity: 0.5;
     fill: #FFFFFF;
     font-size: 48px;
@@ -448,7 +448,7 @@ ul {
     border-radius: 10px;
     background-color: #00757F;
     color: #fff;
-    font-family: Metric;
+    font-family: MetricWeb;
     font-weight: 600;
     font-size: 20px;
     height: 25px;


### PR DESCRIPTION
The stylesheets used by VVT specify "Metric", but elsewhere (particularly from g-chartframe) we use MetricWeb.

When rendering on the server-side via Puppeteer (see: ft-interactive/g-axis#57), none of the fonts on the axis come through. This leads me to believe the `font-family` declarations in the stylesheet are wrong, and they should instead of MetricWeb.

I'd test this hypothesis myself but it's 7 p.m. before a long weekend and I really don't want to merge this before I'm back in the office.