### PR TITLE
Fixes #130, adds automated regression testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,17 @@ jobs:
     working_directory: ~/visual-vocabulary
     # The primary container is an instance of the first list image listed. Your build commands run in this container.
     docker:
-      - image: node:latest
+      - image: node:8
     steps:
       - checkout
+      - run:
+          name: Update container to support Puppeteer
+          command: |
+            apt-get update && apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,3 +23,6 @@ jobs:
             then
                 npm run deploy-css
             fi
+      - run:
+          name: Run regression tests
+          command: npm test

--- a/.tests/regression.test.js
+++ b/.tests/regression.test.js
@@ -13,7 +13,7 @@ const portfinder = require('portfinder');
 
 const TIMEOUT = 20 * 1000;
 
-describe('basic regression tests', function() {
+describe('Visual Vocabulary Templates', function() {
     const exclude = [
         // Excluded templates:
         'choropleth', // Downloading the data takes too long and fails test
@@ -32,10 +32,11 @@ describe('basic regression tests', function() {
 
     let server;
     let port;
-    const browserP = puppeteer.launch();
+    let browser;
 
     beforeAll(async () => {
         try {
+            browser = await puppeteer.launch();
             port = await portfinder.getPortPromise();
             server = http.createServer(connect().use(serveStatic(join(__dirname, '..'))));
             return new Promise(resolve =>
@@ -51,24 +52,25 @@ describe('basic regression tests', function() {
         return new Promise(resolve => server.close(resolve));
     });
 
-    dirs.forEach(dir => {
-        test(`${dir}`, async () => {
-            console.log(`On: ${dir}`);
-            const browser = await browserP;
-            const page = await browser.newPage();
+    describe('basic regression tests', () => {
+        dirs.forEach(dir => {
+            test(`${dir}`, async () => {
+                console.log(`On: ${dir}`);
+                const page = await browser.newPage();
 
-            try {
-                const assertNoError = err => expect(err.message).not.toBeDefined();
+                try {
+                    const assertNoError = err => expect(err.message).not.toBeDefined();
 
-                page.on('pageerror', assertNoError);
-                page.on('requestfailed', assertNoError);
+                    page.on('pageerror', assertNoError);
+                    page.on('requestfailed', assertNoError);
 
-                await page.goto(`http://localhost:${port}/${basename(dir)}`, {waitUntil: 'networkidle0'});
-                return await page.close();
-            } catch (e) {
-                console.error(e);
-                await page.close();
-            }
-        }, TIMEOUT);
+                    await page.goto(`http://localhost:${port}/${basename(dir)}`, {waitUntil: 'networkidle0'});
+                    return await page.close();
+                } catch (e) {
+                    console.error(e);
+                    await page.close();
+                }
+            }, TIMEOUT);
+        });
     });
 });

--- a/.tests/regression.test.js
+++ b/.tests/regression.test.js
@@ -1,0 +1,73 @@
+/**
+ * @file
+ * Regression test to ensure nothing is breaking due to PRs
+ */
+
+const glob = require('glob');
+const { basename, join } = require('path');
+const http = require('http');
+const connect = require('connect');
+const serveStatic = require('serve-static');
+const puppeteer = require('puppeteer');
+const portfinder = require('portfinder');
+
+const TIMEOUT = 20 * 1000;
+
+describe('basic regression tests', function() {
+    const exclude = [
+        // Excluded templates:
+        'choropleth', // Downloading the data takes too long and fails test
+        'poll-tracker', // This is really broken in a lot of ways
+
+        // These don't have testable files
+        'docs',
+        'extras',
+        'node_modules',
+        '.tests',
+    ];
+
+    const dirs = glob.sync(`${__dirname}/../*/`)
+        .map(dir => basename(dir))
+        .filter(dir => !exclude.includes(dir));
+
+    let server;
+    let port;
+    let browser;
+
+    beforeAll(async () => {
+        try {
+            port = await portfinder.getPortPromise();
+            server = http.createServer(connect().use(serveStatic(join(__dirname, '..'))));
+            browser = await puppeteer.launch();
+            return new Promise(resolve =>
+                server.listen(port, resolve));
+        } catch (e) {
+            console.error(e);
+            if (server.close) server.close();
+        }
+    });
+
+    afterAll(async () => {
+        await browser.close();
+        return new Promise(resolve => server.close(resolve));
+    });
+
+    dirs.forEach(dir => {
+        test(`${dir}`, async () => {
+            console.log(`On: ${dir}`);
+            try {
+                const page = await browser.newPage();
+
+                const assertNoError = err => expect(err.message).not.toBeDefined();
+
+                page.on('pageerror', assertNoError);
+                page.on('requestfailed', assertNoError);
+
+                await page.goto(`http://localhost:${port}/${basename(dir)}`, {waitUntil: 'networkidle0'});
+                return await page.close();
+            } catch (e) {
+                await page.close();
+            }
+        }, TIMEOUT);
+    });
+});

--- a/.tests/regression.test.js
+++ b/.tests/regression.test.js
@@ -32,13 +32,12 @@ describe('basic regression tests', function() {
 
     let server;
     let port;
-    let browser;
+    const browserP = puppeteer.launch();
 
     beforeAll(async () => {
         try {
             port = await portfinder.getPortPromise();
             server = http.createServer(connect().use(serveStatic(join(__dirname, '..'))));
-            browser = await puppeteer.launch();
             return new Promise(resolve =>
                 server.listen(port, resolve));
         } catch (e) {
@@ -55,6 +54,7 @@ describe('basic regression tests', function() {
     dirs.forEach(dir => {
         test(`${dir}`, async () => {
             console.log(`On: ${dir}`);
+            const browser = await browserP;
             const page = await browser.newPage();
 
             try {

--- a/.tests/regression.test.js
+++ b/.tests/regression.test.js
@@ -36,7 +36,7 @@ describe('Visual Vocabulary Templates', function() {
 
     beforeAll(async () => {
         try {
-            browser = await puppeteer.launch();
+            browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
             port = await portfinder.getPortPromise();
             server = http.createServer(connect().use(serveStatic(join(__dirname, '..'))));
             return new Promise(resolve =>

--- a/.tests/regression.test.js
+++ b/.tests/regression.test.js
@@ -55,9 +55,10 @@ describe('basic regression tests', function() {
     dirs.forEach(dir => {
         test(`${dir}`, async () => {
             console.log(`On: ${dir}`);
-            try {
-                const page = await browser.newPage();
+            let page;
 
+            try {
+                page = await browser.newPage();
                 const assertNoError = err => expect(err.message).not.toBeDefined();
 
                 page.on('pageerror', assertNoError);
@@ -66,6 +67,7 @@ describe('basic regression tests', function() {
                 await page.goto(`http://localhost:${port}/${basename(dir)}`, {waitUntil: 'networkidle0'});
                 return await page.close();
             } catch (e) {
+                console.error(e);
                 await page.close();
             }
         }, TIMEOUT);

--- a/.tests/regression.test.js
+++ b/.tests/regression.test.js
@@ -55,10 +55,9 @@ describe('basic regression tests', function() {
     dirs.forEach(dir => {
         test(`${dir}`, async () => {
             console.log(`On: ${dir}`);
-            let page;
+            const page = await browser.newPage();
 
             try {
-                page = await browser.newPage();
                 const assertNoError = err => expect(err.message).not.toBeDefined();
 
                 page.on('pageerror', assertNoError);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,83 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+            "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+            "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.0",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "abab": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+            "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+            "dev": true
+        },
         "acorn": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
             "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
             "dev": true
+        },
+        "acorn-globals": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+            "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.0.3"
+            }
         },
         "acorn-jsx": {
             "version": "3.0.1",
@@ -27,6 +99,15 @@
                 }
             }
         },
+        "agent-base": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+            "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "5.0.0"
+            }
+        },
         "ajv": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -41,6 +122,23 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
             "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
             "dev": true
         },
         "ansi-escapes": {
@@ -61,6 +159,301 @@
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
             "dev": true
         },
+        "anymatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
+            "requires": {
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "0.1.6"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "1.0.2"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    }
+                }
+            }
+        },
+        "append-transform": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "1.0.0"
+            }
+        },
         "argparse": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
@@ -69,6 +462,33 @@
             "requires": {
                 "sprintf-js": "1.0.3"
             }
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "1.1.0"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
         },
         "array-find-index": {
             "version": "1.0.2",
@@ -91,10 +511,67 @@
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
             "dev": true
         },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+            "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
             "dev": true
         },
         "aws-sdk": {
@@ -109,6 +586,18 @@
                 "xmlbuilder": "2.6.2"
             }
         },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+            "dev": true
+        },
         "babel-code-frame": {
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
@@ -118,6 +607,168 @@
                 "chalk": "1.1.3",
                 "esutils": "2.0.2",
                 "js-tokens": "3.0.1"
+            }
+        },
+        "babel-core": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+            "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.26.1",
+                "babel-helpers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "convert-source-map": "1.5.1",
+                "debug": "2.6.8",
+                "json5": "0.5.1",
+                "lodash": "4.17.4",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.8",
+                "slash": "1.0.0",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "babel-code-frame": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+                    "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-generator": {
+            "version": "6.26.1",
+            "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+            "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+            "dev": true,
+            "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.4",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+            }
+        },
+        "babel-helpers": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+            }
+        },
+        "babel-jest": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
+            "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-istanbul": "4.1.6",
+                "babel-preset-jest": "22.4.3"
+            }
+        },
+        "babel-messages": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0"
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+            "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-syntax-object-rest-spread": "6.13.0",
+                "find-up": "2.1.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "test-exclude": "4.2.1"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                }
+            }
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
+            "integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
+            "dev": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+            "dev": true
+        },
+        "babel-preset-jest": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
+            "integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-jest-hoist": "22.4.3",
+                "babel-plugin-syntax-object-rest-spread": "6.13.0"
+            }
+        },
+        "babel-register": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+            "dev": true,
+            "requires": {
+                "babel-core": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.1",
+                "home-or-tmp": "2.0.0",
+                "lodash": "4.17.4",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.4.18"
+            },
+            "dependencies": {
+                "source-map-support": {
+                    "version": "0.4.18",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+                    "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.5.7"
+                    }
+                }
             }
         },
         "babel-runtime": {
@@ -130,17 +781,170 @@
                 "regenerator-runtime": "0.11.0"
             }
         },
+        "babel-template": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.4"
+            }
+        },
+        "babel-traverse": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.8",
+                "globals": "9.18.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.4"
+            },
+            "dependencies": {
+                "babel-code-frame": {
+                    "version": "6.26.0",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+                    "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.2"
+                    }
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-types": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "dev": true,
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.4",
+                "to-fast-properties": "1.0.3"
+            }
+        },
+        "babylon": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+            "dev": true
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
+        },
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
             "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
             "dev": true
+        },
+        "boom": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.1"
+            }
         },
         "brace-expansion": {
             "version": "1.1.8",
@@ -152,11 +956,79 @@
                 "concat-map": "0.0.1"
             }
         },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true,
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
+        },
+        "browser-process-hrtime": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+            "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+            "dev": true
+        },
+        "browser-resolve": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "bser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "dev": true,
+            "requires": {
+                "node-int64": "0.4.0"
+            }
+        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
             "dev": true
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
         },
         "caller-path": {
             "version": "0.1.0",
@@ -189,6 +1061,23 @@
                 "map-obj": "1.0.1"
             }
         },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
+        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -202,11 +1091,46 @@
                 "supports-color": "2.0.0"
             }
         },
+        "ci-info": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+            "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+            "dev": true
+        },
         "circular-json": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
             "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
             "dev": true
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
         },
         "cli-cursor": {
             "version": "1.0.2",
@@ -223,6 +1147,27 @@
             "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
             "dev": true
         },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -234,6 +1179,16 @@
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+            }
         },
         "color-convert": {
             "version": "1.9.0",
@@ -250,6 +1205,15 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "combined-stream": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
+        },
         "commander": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
@@ -257,6 +1221,18 @@
             "requires": {
                 "graceful-readlink": "1.0.1"
             }
+        },
+        "compare-versions": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
+            "integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
@@ -275,10 +1251,45 @@
                 "typedarray": "0.0.6"
             }
         },
+        "connect": {
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+            "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "finalhandler": "1.1.0",
+                "parseurl": "1.3.2",
+                "utils-merge": "1.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "contains-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
             "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
         "core-js": {
@@ -302,6 +1313,41 @@
                 "lru-cache": "4.1.1",
                 "shebang-command": "1.2.0",
                 "which": "1.3.0"
+            }
+        },
+        "cryptiles": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+            "dev": true,
+            "requires": {
+                "boom": "5.2.0"
+            },
+            "dependencies": {
+                "boom": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                }
+            }
+        },
+        "cssom": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+            "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "0.2.37",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+            "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+            "dev": true,
+            "requires": {
+                "cssom": "0.3.2"
             }
         },
         "currently-unhandled": {
@@ -577,6 +1623,26 @@
                 "d3-transition": "1.1.0"
             }
         },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
+        },
+        "data-urls": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+            "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+            "dev": true,
+            "requires": {
+                "abab": "1.0.4",
+                "whatwg-mimetype": "2.1.0",
+                "whatwg-url": "6.4.0"
+            }
+        },
         "debug": {
             "version": "2.6.8",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -592,11 +1658,100 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
+        },
+        "default-require-extensions": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+            "dev": true,
+            "requires": {
+                "strip-bom": "2.0.0"
+            },
+            "dependencies": {
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                }
+            }
+        },
+        "define-properties": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "dev": true,
+            "requires": {
+                "foreach": "2.0.5",
+                "object-keys": "1.0.11"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
         },
         "del": {
             "version": "2.2.2",
@@ -613,6 +1768,45 @@
                 "rimraf": "2.6.1"
             }
         },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "detect-indent": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+            "dev": true,
+            "requires": {
+                "repeating": "2.0.1"
+            }
+        },
+        "detect-newline": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
         "doctrine": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
@@ -623,10 +1817,41 @@
                 "isarray": "1.0.0"
             }
         },
+        "domexception": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "4.0.2"
+            }
+        },
         "dotenv": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
             "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+            "dev": true
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
             "dev": true
         },
         "error-ex": {
@@ -636,6 +1861,38 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+            "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "1.1.1",
+                "function-bind": "1.1.1",
+                "has": "1.0.1",
+                "is-callable": "1.1.3",
+                "is-regex": "1.0.4"
+            },
+            "dependencies": {
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+                    "dev": true
+                }
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+            "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+            "dev": true,
+            "requires": {
+                "is-callable": "1.1.3",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.1"
             }
         },
         "es5-ext": {
@@ -673,6 +1930,21 @@
                 "event-emitter": "0.3.5"
             }
         },
+        "es6-promise": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+            "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "4.2.4"
+            }
+        },
         "es6-set": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
@@ -708,11 +1980,39 @@
                 "es6-symbol": "3.1.1"
             }
         },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
+        },
+        "escodegen": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+            "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+            "dev": true,
+            "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
         },
         "escope": {
             "version": "3.6.0",
@@ -1031,6 +2331,12 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
         "event-emitter": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -1039,6 +2345,15 @@
             "requires": {
                 "d": "1.0.0",
                 "es5-ext": "0.10.23"
+            }
+        },
+        "exec-sh": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+            "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+            "dev": true,
+            "requires": {
+                "merge": "1.2.0"
             }
         },
         "execa": {
@@ -1056,10 +2371,145 @@
                 "strip-eof": "1.0.0"
             }
         },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
         "exit-hook": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
             "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "2.2.3"
+            }
+        },
+        "expect": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+            "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "jest-diff": "22.4.3",
+                "jest-get-type": "22.4.3",
+                "jest-matcher-utils": "22.4.3",
+                "jest-message-util": "22.4.3",
+                "jest-regex-util": "22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                }
+            }
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
+        "extract-zip": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+            "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "1.6.0",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.0",
+                "yauzl": "2.4.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
         "fast-levenshtein": {
@@ -1067,6 +2517,15 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "fb-watchman": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+            "dev": true,
+            "requires": {
+                "bser": "2.0.0"
+            }
         },
         "fd-slicer": {
             "version": "1.0.1",
@@ -1094,6 +2553,61 @@
             "requires": {
                 "flat-cache": "1.2.2",
                 "object-assign": "4.1.1"
+            }
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "fileset": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+            "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "minimatch": "3.0.4"
+            }
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "dev": true,
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+            "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.3.1",
+                "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "find-up": {
@@ -1124,11 +2638,968 @@
                 "write": "0.2.1"
             }
         },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2"
+            }
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+            "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+            }
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "0.2.2"
+            }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
+        },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "2.10.0",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
         },
         "ft-graphics-deploy": {
             "version": "2.1.6",
@@ -1168,6 +3639,27 @@
                         "supports-color": "4.5.0"
                     }
                 },
+                "rimraf": {
+                    "version": "2.2.8",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                    "dev": true
+                },
+                "s3": {
+                    "version": "github:callumlocke/node-s3-client#a1c25dd322bb22617a7255e84369b1e1c0289397",
+                    "dev": true,
+                    "requires": {
+                        "aws-sdk": "2.4.14",
+                        "fd-slicer": "1.0.1",
+                        "findit2": "2.2.3",
+                        "graceful-fs": "4.1.11",
+                        "mime": "1.2.11",
+                        "mkdirp": "0.5.1",
+                        "pend": "1.2.0",
+                        "rimraf": "2.2.8",
+                        "streamsink": "1.2.0"
+                    }
+                },
                 "supports-color": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -1205,6 +3697,12 @@
                 "is-property": "1.0.2"
             }
         },
+        "get-caller-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+            "dev": true
+        },
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -1216,6 +3714,21 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
         },
         "glob": {
             "version": "7.1.2",
@@ -1229,6 +3742,25 @@
                 "minimatch": "3.0.4",
                 "once": "1.4.0",
                 "path-is-absolute": "1.0.1"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "dev": true,
+            "requires": {
+                "is-glob": "2.0.1"
             }
         },
         "globals": {
@@ -1262,6 +3794,71 @@
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+            "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.1.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                }
+            }
+        },
         "has": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -1286,11 +3883,160 @@
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "hawk": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+            "dev": true,
+            "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
+            }
+        },
+        "hoek": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+            "dev": true
+        },
+        "home-or-tmp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+            }
+        },
         "hosted-git-info": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
             "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
             "dev": true
+        },
+        "html-encoding-sniffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "1.0.3"
+            }
+        },
+        "http-errors": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "dev": true,
+            "requires": {
+                "depd": "1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": "1.5.0"
+            },
+            "dependencies": {
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+                    "dev": true
+                }
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
         },
         "iconv-lite": {
             "version": "0.4.18",
@@ -1302,6 +4048,36 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
             "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
             "dev": true
+        },
+        "import-local": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+            "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "2.0.0",
+                "resolve-cwd": "2.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                },
+                "pkg-dir": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+                    "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "2.1.0"
+                    }
+                }
+            }
         },
         "imurmurhash": {
             "version": "0.1.4",
@@ -1385,10 +4161,40 @@
             "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
             "dev": true
         },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "1.3.1"
+            }
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
         "is-builtin-module": {
@@ -1399,6 +4205,82 @@
             "requires": {
                 "builtin-modules": "1.1.1"
             }
+        },
+        "is-callable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+            "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+            "dev": true
+        },
+        "is-ci": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+            "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+            "dev": true,
+            "requires": {
+                "ci-info": "1.1.3"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true
         },
         "is-finite": {
             "version": "1.0.2",
@@ -1418,6 +4300,21 @@
                 "number-is-nan": "1.0.1"
             }
         },
+        "is-generator-fn": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
         "is-my-json-valid": {
             "version": "2.16.0",
             "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
@@ -1428,6 +4325,32 @@
                 "generate-object-property": "1.2.0",
                 "jsonpointer": "4.0.1",
                 "xtend": "4.0.1"
+            }
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "is-odd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+            "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
             }
         },
         "is-path-cwd": {
@@ -1454,11 +4377,49 @@
                 "path-is-inside": "1.0.2"
             }
         },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
         "is-property": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
             "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
             "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1"
+            }
         },
         "is-resolvable": {
             "version": "1.0.0",
@@ -1475,10 +4436,28 @@
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
         },
+        "is-symbol": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+            "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+            "dev": true
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
         "isarray": {
@@ -1492,6 +4471,927 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "istanbul-api": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
+            "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+            "dev": true,
+            "requires": {
+                "async": "2.6.0",
+                "compare-versions": "3.1.0",
+                "fileset": "2.0.3",
+                "istanbul-lib-coverage": "1.2.0",
+                "istanbul-lib-hook": "1.2.0",
+                "istanbul-lib-instrument": "1.10.1",
+                "istanbul-lib-report": "1.1.4",
+                "istanbul-lib-source-maps": "1.2.4",
+                "istanbul-reports": "1.3.0",
+                "js-yaml": "3.8.4",
+                "mkdirp": "0.5.1",
+                "once": "1.4.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
+                    "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "3.1.0",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1",
+                        "source-map": "0.5.7"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-coverage": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+            "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
+            "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
+            "dev": true,
+            "requires": {
+                "append-transform": "0.4.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+            "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+            "dev": true,
+            "requires": {
+                "babel-generator": "6.26.1",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "semver": "5.3.0"
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+            "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+            "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+            "dev": true,
+            "requires": {
+                "debug": "3.1.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
+            "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+            "dev": true,
+            "requires": {
+                "handlebars": "4.0.11"
+            }
+        },
+        "jest": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
+            "integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+            "dev": true,
+            "requires": {
+                "import-local": "1.0.0",
+                "jest-cli": "22.4.3"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+                    "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "jest-cli": {
+                    "version": "22.4.3",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
+                    "integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "3.1.0",
+                        "chalk": "2.4.0",
+                        "exit": "0.1.2",
+                        "glob": "7.1.2",
+                        "graceful-fs": "4.1.11",
+                        "import-local": "1.0.0",
+                        "is-ci": "1.1.0",
+                        "istanbul-api": "1.3.1",
+                        "istanbul-lib-coverage": "1.2.0",
+                        "istanbul-lib-instrument": "1.10.1",
+                        "istanbul-lib-source-maps": "1.2.3",
+                        "jest-changed-files": "22.4.3",
+                        "jest-config": "22.4.3",
+                        "jest-environment-jsdom": "22.4.3",
+                        "jest-get-type": "22.4.3",
+                        "jest-haste-map": "22.4.3",
+                        "jest-message-util": "22.4.3",
+                        "jest-regex-util": "22.4.3",
+                        "jest-resolve-dependencies": "22.4.3",
+                        "jest-runner": "22.4.3",
+                        "jest-runtime": "22.4.3",
+                        "jest-snapshot": "22.4.3",
+                        "jest-util": "22.4.3",
+                        "jest-validate": "22.4.3",
+                        "jest-worker": "22.4.3",
+                        "micromatch": "2.3.11",
+                        "node-notifier": "5.2.1",
+                        "realpath-native": "1.0.0",
+                        "rimraf": "2.6.1",
+                        "slash": "1.0.0",
+                        "string-length": "2.0.0",
+                        "strip-ansi": "4.0.0",
+                        "which": "1.3.0",
+                        "yargs": "10.1.2"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-changed-files": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+            "integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+            "dev": true,
+            "requires": {
+                "throat": "4.1.0"
+            }
+        },
+        "jest-config": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
+            "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.0",
+                "glob": "7.1.2",
+                "jest-environment-jsdom": "22.4.3",
+                "jest-environment-node": "22.4.3",
+                "jest-get-type": "22.4.3",
+                "jest-jasmine2": "22.4.3",
+                "jest-regex-util": "22.4.3",
+                "jest-resolve": "22.4.3",
+                "jest-util": "22.4.3",
+                "jest-validate": "22.4.3",
+                "pretty-format": "22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-diff": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+            "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.0",
+                "diff": "3.5.0",
+                "jest-get-type": "22.4.3",
+                "pretty-format": "22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-docblock": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+            "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+            "dev": true,
+            "requires": {
+                "detect-newline": "2.1.0"
+            }
+        },
+        "jest-environment-jsdom": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+            "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "22.4.3",
+                "jest-util": "22.4.3",
+                "jsdom": "11.8.0"
+            }
+        },
+        "jest-environment-node": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+            "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+            "dev": true,
+            "requires": {
+                "jest-mock": "22.4.3",
+                "jest-util": "22.4.3"
+            }
+        },
+        "jest-get-type": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+            "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+            "dev": true,
+            "requires": {
+                "fb-watchman": "2.0.0",
+                "graceful-fs": "4.1.11",
+                "jest-docblock": "22.4.3",
+                "jest-serializer": "22.4.3",
+                "jest-worker": "22.4.3",
+                "micromatch": "2.3.11",
+                "sane": "2.5.0"
+            }
+        },
+        "jest-jasmine2": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
+            "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.0",
+                "co": "4.6.0",
+                "expect": "22.4.3",
+                "graceful-fs": "4.1.11",
+                "is-generator-fn": "1.0.0",
+                "jest-diff": "22.4.3",
+                "jest-matcher-utils": "22.4.3",
+                "jest-message-util": "22.4.3",
+                "jest-snapshot": "22.4.3",
+                "jest-util": "22.4.3",
+                "source-map-support": "0.5.4"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-leak-detector": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+            "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+            "dev": true,
+            "requires": {
+                "pretty-format": "22.4.3"
+            }
+        },
+        "jest-matcher-utils": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+            "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.0",
+                "jest-get-type": "22.4.3",
+                "pretty-format": "22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-message-util": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+            "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.44",
+                "chalk": "2.4.0",
+                "micromatch": "2.3.11",
+                "slash": "1.0.0",
+                "stack-utils": "1.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-mock": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+            "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+            "dev": true
+        },
+        "jest-regex-util": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+            "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+            "dev": true
+        },
+        "jest-resolve": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+            "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+            "dev": true,
+            "requires": {
+                "browser-resolve": "1.11.2",
+                "chalk": "2.4.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-resolve-dependencies": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+            "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+            "dev": true,
+            "requires": {
+                "jest-regex-util": "22.4.3"
+            }
+        },
+        "jest-runner": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
+            "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "jest-config": "22.4.3",
+                "jest-docblock": "22.4.3",
+                "jest-haste-map": "22.4.3",
+                "jest-jasmine2": "22.4.3",
+                "jest-leak-detector": "22.4.3",
+                "jest-message-util": "22.4.3",
+                "jest-runtime": "22.4.3",
+                "jest-util": "22.4.3",
+                "jest-worker": "22.4.3",
+                "throat": "4.1.0"
+            }
+        },
+        "jest-runtime": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
+            "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+            "dev": true,
+            "requires": {
+                "babel-core": "6.26.0",
+                "babel-jest": "22.4.3",
+                "babel-plugin-istanbul": "4.1.6",
+                "chalk": "2.4.0",
+                "convert-source-map": "1.5.1",
+                "exit": "0.1.2",
+                "graceful-fs": "4.1.11",
+                "jest-config": "22.4.3",
+                "jest-haste-map": "22.4.3",
+                "jest-regex-util": "22.4.3",
+                "jest-resolve": "22.4.3",
+                "jest-util": "22.4.3",
+                "jest-validate": "22.4.3",
+                "json-stable-stringify": "1.0.1",
+                "micromatch": "2.3.11",
+                "realpath-native": "1.0.0",
+                "slash": "1.0.0",
+                "strip-bom": "3.0.0",
+                "write-file-atomic": "2.3.0",
+                "yargs": "10.1.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-serializer": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+            "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+            "dev": true
+        },
+        "jest-snapshot": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+            "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.0",
+                "jest-diff": "22.4.3",
+                "jest-matcher-utils": "22.4.3",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "pretty-format": "22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-util": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+            "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+            "dev": true,
+            "requires": {
+                "callsites": "2.0.0",
+                "chalk": "2.4.0",
+                "graceful-fs": "4.1.11",
+                "is-ci": "1.1.0",
+                "jest-message-util": "22.4.3",
+                "mkdirp": "0.5.1",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "callsites": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+                    "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-validate": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
+            "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.0",
+                "jest-config": "22.4.3",
+                "jest-get-type": "22.4.3",
+                "leven": "2.1.0",
+                "pretty-format": "22.4.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-worker": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+            "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+            "dev": true,
+            "requires": {
+                "merge-stream": "1.0.1"
+            }
         },
         "jmespath": {
             "version": "0.15.0",
@@ -1515,6 +5415,79 @@
                 "esprima": "3.1.3"
             }
         },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "jsdom": {
+            "version": "11.8.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.8.0.tgz",
+            "integrity": "sha512-fZZSH6P8tVqYIQl0WKpZuQljPu2cW41Uj/c9omtyGwjwZCB8c82UAi7BSQs/F1FgWovmZsoU02z3k28eHp0Cdw==",
+            "dev": true,
+            "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.5.3",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "data-urls": "1.0.0",
+                "domexception": "1.0.1",
+                "escodegen": "1.9.1",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.3.0",
+                "nwmatcher": "1.4.4",
+                "parse5": "4.0.0",
+                "pn": "1.1.0",
+                "request": "2.85.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.4",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-mimetype": "2.1.0",
+                "whatwg-url": "6.4.0",
+                "ws": "4.1.0",
+                "xml-name-validator": "3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "dev": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "dev": true
+                }
+            }
+        },
+        "jsesc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
         "json-stable-stringify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -1523,6 +5496,18 @@
             "requires": {
                 "jsonify": "0.0.0"
             }
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
         },
         "jsonify": {
             "version": "0.0.0",
@@ -1534,6 +5519,55 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
             "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.6"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true,
+            "optional": true
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
+            "requires": {
+                "invert-kv": "1.0.0"
+            }
+        },
+        "left-pad": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "dev": true
+        },
+        "leven": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
             "dev": true
         },
         "levn": {
@@ -1586,6 +5620,27 @@
             "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
             "dev": true
         },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+            "dev": true,
+            "requires": {
+                "js-tokens": "3.0.1"
+            }
+        },
         "loud-rejection": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -1606,11 +5661,44 @@
                 "yallist": "2.1.2"
             }
         },
+        "makeerror": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+            "dev": true,
+            "requires": {
+                "tmpl": "1.0.4"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
         "map-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "1.0.1"
+            }
+        },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
         },
         "meow": {
             "version": "3.7.0",
@@ -1692,10 +5780,67 @@
                 }
             }
         },
+        "merge": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+            "dev": true
+        },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.2"
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            }
+        },
         "mime": {
             "version": "1.2.11",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
             "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.33.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
             "dev": true
         },
         "minimatch": {
@@ -1713,6 +5858,27 @@
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1728,11 +5894,84 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
+        "nan": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+            "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+            "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
+        },
+        "node-notifier": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+            "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+            "dev": true,
+            "requires": {
+                "growly": "1.3.0",
+                "semver": "5.5.0",
+                "shellwords": "0.1.1",
+                "which": "1.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+                    "dev": true
+                }
+            }
         },
         "normalize-package-data": {
             "version": "2.3.8",
@@ -1744,6 +5983,15 @@
                 "is-builtin-module": "1.0.0",
                 "semver": "5.3.0",
                 "validate-npm-package-license": "3.0.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "npm-run-path": {
@@ -1761,11 +6009,114 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true
         },
+        "nwmatcher": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+            "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
+        },
+        "object-keys": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "es-abstract": "1.11.0"
+            }
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
         },
         "once": {
             "version": "1.4.0",
@@ -1781,6 +6132,24 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
             "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
             "dev": true
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                }
+            }
         },
         "optionator": {
             "version": "0.8.2",
@@ -1801,6 +6170,34 @@
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
+        },
+        "os-locale": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "dev": true,
+            "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                }
+            }
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -1833,6 +6230,18 @@
             "integrity": "sha512-w7N3anrhTV0kUoUp2reEY8716DScD/Z958QZm6E7VbqzoPs6TnbWFrBBHUzgpxcBoKFkFh3NQ0AS6rxIIKH+fQ==",
             "dev": true
         },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
         "parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -1841,6 +6250,24 @@
             "requires": {
                 "error-ex": "1.3.1"
             }
+        },
+        "parse5": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "dev": true
+        },
+        "parseurl": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
         },
         "path-exists": {
             "version": "2.1.0",
@@ -1890,6 +6317,12 @@
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
             "dev": true
         },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1920,10 +6353,80 @@
                 "find-up": "1.1.2"
             }
         },
+        "pn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "dev": true
+        },
+        "portfinder": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+            "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "debug": "2.6.8",
+                "mkdirp": "0.5.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                }
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "pretty-format": {
+            "version": "22.4.3",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+            "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "3.0.0",
+                "ansi-styles": "3.2.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.0"
+                    }
+                }
+            }
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
             "dev": true
         },
         "process-nextick-args": {
@@ -1932,10 +6435,116 @@
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
             "dev": true
         },
+        "progress": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "dev": true
+        },
+        "proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+            "dev": true
+        },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+            "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+            "dev": true
+        },
+        "puppeteer": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.3.0.tgz",
+            "integrity": "sha512-wx10aPQPpGJVxdB6yoDSLm9p4rCwARUSLMVV0bx++owuqkvviXKyiFM3EWsywaFmjOKNPXacIjplF7xhHiFP3w==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.8",
+                "extract-zip": "1.6.6",
+                "https-proxy-agent": "2.2.1",
+                "mime": "1.6.0",
+                "progress": "2.0.0",
+                "proxy-from-env": "1.0.0",
+                "rimraf": "2.6.1",
+                "ws": "3.3.3"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+                    "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "1.0.0",
+                        "safe-buffer": "5.1.1",
+                        "ultron": "1.1.1"
+                    }
+                }
+            }
+        },
+        "qs": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+            "dev": true
+        },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
             "dev": true
         },
         "read-pkg": {
@@ -2013,6 +6622,15 @@
                 }
             }
         },
+        "realpath-native": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+            "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+            "dev": true,
+            "requires": {
+                "util.promisify": "1.0.0"
+            }
+        },
         "rechoir": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -2038,6 +6656,43 @@
             "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
             "dev": true
         },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
         "repeating": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -2046,6 +6701,68 @@
             "requires": {
                 "is-finite": "1.0.2"
             }
+        },
+        "request": {
+            "version": "2.85.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.4"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
         },
         "require-uncached": {
             "version": "1.0.3",
@@ -2066,10 +6783,33 @@
                 "path-parse": "1.0.5"
             }
         },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "3.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+                    "dev": true
+                }
+            }
+        },
         "resolve-from": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
             "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "dev": true
         },
         "restore-cursor": {
@@ -2080,6 +6820,22 @@
             "requires": {
                 "exit-hook": "1.1.1",
                 "onetime": "1.1.0"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "align-text": "0.1.4"
             }
         },
         "rimraf": {
@@ -2111,34 +6867,318 @@
             "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
             "dev": true
         },
-        "s3": {
-            "version": "github:callumlocke/node-s3-client#a1c25dd322bb22617a7255e84369b1e1c0289397",
-            "dev": true,
-            "requires": {
-                "aws-sdk": "2.4.14",
-                "fd-slicer": "1.0.1",
-                "findit2": "2.2.3",
-                "graceful-fs": "4.1.11",
-                "mime": "1.2.11",
-                "mkdirp": "0.5.1",
-                "pend": "1.2.0",
-                "rimraf": "2.2.8",
-                "streamsink": "1.2.0"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.2.8",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-                    "dev": true
-                }
-            }
-        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
             "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "0.1.15"
+            }
+        },
+        "sane": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
+            "integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
+            "dev": true,
+            "requires": {
+                "anymatch": "2.0.0",
+                "exec-sh": "0.2.1",
+                "fb-watchman": "2.0.0",
+                "fsevents": "1.1.3",
+                "micromatch": "3.1.10",
+                "minimist": "1.2.0",
+                "walker": "1.0.7",
+                "watch": "0.18.0"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "0.1.6"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "1.0.2"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
         },
         "sax": {
             "version": "1.1.5",
@@ -2150,6 +7190,97 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
             "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "dev": true
+        },
+        "send": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "1.6.3",
+                "mime": "1.4.1",
+                "ms": "2.0.0",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.4.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "mime": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+                    "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                    "dev": true
+                }
+            }
+        },
+        "serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+            "dev": true,
+            "requires": {
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
+                "send": "0.16.2"
+            }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
             "dev": true
         },
         "shebang-command": {
@@ -2178,16 +7309,187 @@
                 "rechoir": "0.6.2"
             }
         },
+        "shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "dev": true
+        },
         "slice-ansi": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
             "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.8",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.1",
+                "use": "3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "1.0.2"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "sntp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.1"
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-resolve": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+            "dev": true,
+            "requires": {
+                "atob": "2.1.0",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
+            "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+            "dev": true,
+            "requires": {
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
         "spdx-correct": {
@@ -2211,10 +7513,74 @@
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
             "dev": true
         },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "3.0.2"
+            }
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+            "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "stack-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "0.1.6"
+                    }
+                }
+            }
+        },
+        "statuses": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+            "dev": true
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
             "dev": true
         },
         "streamsink": {
@@ -2222,6 +7588,33 @@
             "resolved": "https://registry.npmjs.org/streamsink/-/streamsink-1.2.0.tgz",
             "integrity": "sha1-76/unx4i01ke1949yqlcP1559zw=",
             "dev": true
+        },
+        "string-length": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+            "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+            "dev": true,
+            "requires": {
+                "astral-regex": "1.0.0",
+                "strip-ansi": "4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
         },
         "string-width": {
             "version": "1.0.2",
@@ -2242,6 +7635,12 @@
             "requires": {
                 "safe-buffer": "5.1.1"
             }
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -2285,10 +7684,365 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "symbol-tree": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "dev": true
+        },
+        "test-exclude": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+            "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+            "dev": true,
+            "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "3.1.10",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "0.1.6"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "1.0.2"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "0.1.1"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                },
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
+                    }
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.3.8",
+                        "path-type": "1.1.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
+                }
+            }
+        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "throat": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
             "dev": true
         },
         "through": {
@@ -2316,10 +8070,96 @@
                 "tmp": "0.0.31"
             }
         },
+        "tmpl": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
+                }
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+            "dev": true,
+            "requires": {
+                "punycode": "2.1.0"
+            }
+        },
         "trim-newlines": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
             "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
         "tryit": {
@@ -2327,6 +8167,22 @@
             "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
             "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
             "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
         },
         "type-check": {
             "version": "0.3.2",
@@ -2343,6 +8199,163 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
         },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                    "dev": true,
+                    "optional": true
+                },
+                "yargs": {
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                    }
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "ultron": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+            "dev": true
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
+            "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
+                    }
+                }
+            }
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "use": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+            "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+            "dev": true,
+            "requires": {
+                "kind-of": "6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
         "user-home": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -2358,6 +8371,28 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
+        "util.promisify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "object.getownpropertydescriptors": "2.0.3"
+            }
+        },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+            "dev": true
+        },
         "validate-npm-package-license": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -2366,6 +8401,93 @@
             "requires": {
                 "spdx-correct": "1.0.2",
                 "spdx-expression-parse": "1.0.4"
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            }
+        },
+        "w3c-hr-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "0.1.2"
+            }
+        },
+        "walker": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+            "dev": true,
+            "requires": {
+                "makeerror": "1.0.11"
+            }
+        },
+        "watch": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+            "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+            "dev": true,
+            "requires": {
+                "exec-sh": "0.2.1",
+                "minimist": "1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true
+        },
+        "whatwg-encoding": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+            "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.19"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.19",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+                    "dev": true
+                }
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+            "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+            "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
             }
         },
         "which": {
@@ -2377,11 +8499,34 @@
                 "isexe": "2.0.0"
             }
         },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true,
+            "optional": true
+        },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
             "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+            }
         },
         "wrappy": {
             "version": "1.0.2",
@@ -2397,6 +8542,33 @@
             "requires": {
                 "mkdirp": "0.5.1"
             }
+        },
+        "write-file-atomic": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "ws": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+            "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
         },
         "xml2js": {
             "version": "0.4.15",
@@ -2436,11 +8608,116 @@
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
             "dev": true
         },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
+        },
+        "yargs": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+            "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+            "dev": true,
+            "requires": {
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "8.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+            "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "4.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                }
+            }
+        },
+        "yauzl": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+            "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+            "dev": true,
+            "requires": {
+                "fd-slicer": "1.0.1"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "url": "git+https://github.com/ft-interactive/visual-vocabulary-templates.git"
     },
     "scripts": {
-        "deploy-css": "ft-graphics-deploy --confirm --local-dir=./docs/"
+        "deploy-css": "ft-graphics-deploy --confirm --local-dir=./docs/",
+        "test": "jest ./.tests/*"
     },
     "keywords": [],
     "author": "Financial Times Interactive Graphics",
@@ -17,14 +18,25 @@
     },
     "homepage": "https://github.com/ft-interactive/visual-vocabulary-templates#readme",
     "devDependencies": {
+        "connect": "^3.6.6",
         "eslint": "^3.19.0",
         "eslint-config-airbnb-base": "^11.2.0",
         "eslint-plugin-import": "^2.6.0",
-        "ft-graphics-deploy": "^2.1.6"
+        "ft-graphics-deploy": "^2.1.6",
+        "glob": "^7.1.2",
+        "jest": "^22.4.3",
+        "portfinder": "^1.0.13",
+        "puppeteer": "^1.3.0",
+        "serve-static": "^1.13.2"
     },
     "dependencies": {
         "d3": "^4.9.1",
         "g-chartcolour": "^0.8.11",
         "locate-path": "^2.0.0"
+    },
+    "jest": {
+        "verbose": true,
+        "expand": true,
+        "bail": true
     }
 }

--- a/population-pyramid/index.js
+++ b/population-pyramid/index.js
@@ -96,7 +96,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, '')
+parseData.load(dataFile)
     .then(({ seriesNames, plotData, valueExtent }) => {
     // Draw the frames
         Object.keys(frame).forEach((frameName) => {

--- a/population-pyramid/parseData.js
+++ b/population-pyramid/parseData.js
@@ -10,9 +10,9 @@ import loadData from '@financial-times/load-data';
  * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function load(url, options) {
+export function load(url, options = {}) {
     const { dateFormat } = options;
-    return loadData(url).then((result) => {
+    return loadData(url).then((data) => {
         // automatically calculate the seriesnames excluding the "marker" and "annotate column"
         const seriesNames = getSeriesNames(data.columns);
         const groupNames = data.map(d => d.name).filter(d => d); // create an array of the group names

--- a/sankey-2018/index.js
+++ b/sankey-2018/index.js
@@ -8,7 +8,7 @@ import * as gChartcolour from 'g-chartcolour';
 // User defined constants similar to version 2
 const dateStructure = '%d/%m/%Y';
 
-const dataFile = 'data.csv?b';
+const dataFile = 'data.csv';
 
 const sharedConfig = {
     // title: 'German election 2017: which voters switched parties?',
@@ -82,9 +82,9 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, dateStructure).then((data) => {
+parseData.load(dataFile, dateStructure).then((data) => {
 
-    // define chart    
+    // define chart
     const myChart = custom.draw();
 
     Object.keys(frame).forEach((frameName) => {
@@ -232,7 +232,7 @@ parseData.fromCSV(dataFile, dateStructure).then((data) => {
           .map(d => d.key);
 
         console.log("nodes", plotData.nodes)
-    
+
         let cat=[];
 
         // loop through each link replacing the text with its index from node
@@ -284,10 +284,10 @@ parseData.fromCSV(dataFile, dateStructure).then((data) => {
           .data(plotData.links)
           .enter().append("path")
           .attr("id",function(d) {
-            return d.source.name.replace(/HL_|HR_|RL_/g,"") + "_to_" + 
+            return d.source.name.replace(/HL_|HR_|RL_/g,"") + "_to_" +
                 d.target.name;
             })
-          .attr("transform", 
+          .attr("transform",
               "translate(" + plotMargin.sankey + "," + 0 + ")")
           .attr("class", media+"link")
           .style("opacity", d => d.highlight == 1 ? 1:0.3)
@@ -304,10 +304,10 @@ parseData.fromCSV(dataFile, dateStructure).then((data) => {
           .data(plotData.nodes)
           .enter().append("g")
             .attr("class", media+"node")
-            .attr("transform", function(d) { 
+            .attr("transform", function(d) {
               return "translate(" + (d.x)+ "," + (d.y) + ")"; })
           .call(d3.drag()
-            .on("start", function() { 
+            .on("start", function() {
                 this.parentNode.appendChild(this); })
             .on("drag", function(d){
               d3.select(this)
@@ -348,7 +348,7 @@ parseData.fromCSV(dataFile, dateStructure).then((data) => {
         .styles({
           "font-size": currentFrame.rem()-2
         })
-        .attr("transform", 
+        .attr("transform",
               "translate(" + plotMargin.sankey + "," + 0 + ")")
         .style("text-anchor", function (d){
             if(d.x<plotWidth*0.3) {
@@ -375,7 +375,7 @@ parseData.fromCSV(dataFile, dateStructure).then((data) => {
             }
             else {return -8}
         })
-        .attr("transform", 
+        .attr("transform",
               "translate(" + plotMargin.sankey + "," + 0 + ")")
         .style("text-anchor", function (d){
             if(d.x<plotWidth*0.3) {

--- a/sankey-2018/parseData.js
+++ b/sankey-2018/parseData.js
@@ -12,7 +12,7 @@ import loadData from '@financial-times/load-data';
  */
 export function load(url, options) {
     const { dateFormat } = options;
-    return loadData(url).then((result) => {
+    return loadData(url).then((data) => {
         // make sure all the dates in the date column are a date object
         const parseDate = d3.timeParse(dateFormat);
 

--- a/small-multiple-column-group/index.js
+++ b/small-multiple-column-group/index.js
@@ -108,7 +108,7 @@ d3.selectAll('.framed')
         figure.select('svg')
             .call(frame[figure.node().dataset.frame]);
     });
-parseData.fromCSV(dataFile, { yMin, dataDivisor })
+parseData.load(dataFile, { yMin, dataDivisor })
     .then(({
         columnNames, plotData, valueExtent,
     }) => {

--- a/small-multiple-column-group/parseData.js
+++ b/small-multiple-column-group/parseData.js
@@ -10,10 +10,10 @@ import loadData from '@financial-times/load-data';
  * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function load(url, options) {
+export function load(url, options = {}) {
     const { dateFormat, yMin, dataDivisor } = options;
 
-    return loadData(url).then((result) => {
+    return loadData(url).then((data) => {
         // Automatically calculate the seriesnames excluding the "marker" and "annotate column"
         const seriesNames = getSeriesNames(data.columns);
 

--- a/small-multiple-multi-line/index.js
+++ b/small-multiple-multi-line/index.js
@@ -132,7 +132,7 @@ d3.selectAll('.framed')
         figure.select('svg')
             .call(frame[figure.node().dataset.frame]);
     });
-parseData.fromCSV(dataFile, dateStructure, { yMin, joinPoints, dataDivisor }).then(({
+parseData.load(dataFile, { dateStructure, yMin, joinPoints, dataDivisor }).then(({
     seriesNames, groupNamesReduced, data, newData, valueExtent, highlights, annos,
 }) => {
     Object.keys(frame).forEach((frameName) => {

--- a/small-multiple-multi-line/parseData.js
+++ b/small-multiple-multi-line/parseData.js
@@ -10,10 +10,10 @@ import loadData from '@financial-times/load-data';
  * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function load(url, options) { // eslint-disable-line
-    const { dateFormat, yMin, joinPoints, dataDivisor } = options;
+export function load(url, options = {}) { // eslint-disable-line
+    const { dateStructure, yMin, joinPoints, dataDivisor } = options;
 
-    return loadData(url).then((result) => {
+    return loadData(url).then((data) => {
         // make sure all the dates in the date column are a date object
         const parseDate = d3.timeParse(dateStructure);
         data.forEach((d) => {

--- a/spine/index.js
+++ b/spine/index.js
@@ -52,13 +52,13 @@ const frame = {
    .margin({ top: 40, left: 7, bottom: 35, right: 7 })
    // .title("Put headline here")
    /* Print column widths */
-    //.width(53.71)// 1 col 
-    .width(112.25)// 2 col 
+    //.width(53.71)// 1 col
+    .width(112.25)// 2 col
     //.width(170.8)// 3 col
     //.width(229.34)// 4 col
-    //.width(287.88)// 5 col 
+    //.width(287.88)// 5 col
     //.width(346.43)// 6 col
-    //.width(74)// markets std print 
+    //.width(74)// markets std print
     .height(58.21),//markets std print
 
 
@@ -82,7 +82,7 @@ d3.selectAll('.framed')
             .call(frame[figure.node().dataset.frame]);
     });
 
-parseData.fromCSV(dataFile, { sort, sortOn })
+parseData.load(dataFile, { sort, sortOn })
 .then(({ seriesNames, plotData, valueExtent }) => {
     // Draw the frames
     Object.keys(frame).forEach((frameName) => {

--- a/spine/parseData.js
+++ b/spine/parseData.js
@@ -10,10 +10,10 @@ import loadData from '@financial-times/load-data';
  * @param  {String} url Path to CSV/TSV/JSON file
  * @return {Object}     Object containing series names, value extent and raw data object
  */
-export function load(url, options) {
+export function load(url, options = {}) {
     const { sort, sortOn, dateFormat } = options;
 
-    return loadData(url).then((result) => {
+    return loadData(url).then((data) => {
         // automatically calculate the seriesnames excluding the "marker" and "annotate column"
         const seriesNames = getSeriesNames(data.columns);
         const groupNames = data.map(d => d.name).filter(d => d); // create an array of the group names


### PR DESCRIPTION
After I broke five charts with replacing `parseData.fromCSV` with `parseData.load` (which this PR fixes), I figured it wouldn't be the worst idea to add some very light regression testing to ensure that templates don't throw exceptions out of the gate.

The test running sets up a mini server and then uses headless Chrome to load each template in serial, waits until no further requests are being made by the browser, then passes if no resource or JS errors are thrown. This only gets run by CircleCI, meaning we get little badges telling us whether it passed or not, and we can investigate when PRs fail. 