### PR TITLE
Treat 0 as a number/data point in extentMulti function

### DIFF
--- a/candlestick/parseData.js
+++ b/candlestick/parseData.js
@@ -130,7 +130,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => +row[key])
             .map((item) => {
-                if (!item || item === '*') {
+                if (item !== 0 && (!item || item === '*')) {
                     return yMin;
                 }
                 return Number(item);

--- a/line-dual-axis/parseData.js
+++ b/line-dual-axis/parseData.js
@@ -47,7 +47,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
         .map((item) => {
-            if (!item || item === '*') {
+            if (item !== 0 && (!item || item === '*')) {
                 return yMin;
             }
             return Number(item);

--- a/line-vertical/parseData.js
+++ b/line-vertical/parseData.js
@@ -125,7 +125,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
             .map((item) => {
-                if (!item || item === '*') {
+                if (item !== 0 && (!item || item === '*')) {
                     return yMin;
                 }
                 return Number(item);

--- a/line/parseData.js
+++ b/line/parseData.js
@@ -103,7 +103,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
         .map((item) => {
-            if (!item || item === '*') {
+            if (item !== 0 && (!item || item === '*')) {
                 return yMin;
             }
             return Number(item);

--- a/small-multiple-area/parseData.js
+++ b/small-multiple-area/parseData.js
@@ -79,7 +79,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
             .map((item) => {
-                if (!item || item === '*') {
+                if (item !== 0 && (!item || item === '*')) {
                     return yMin;
                 }
                 return Number(item);

--- a/small-multiple-bar/parseData.js
+++ b/small-multiple-bar/parseData.js
@@ -83,7 +83,7 @@ export function extentMulti(d, columns, xMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
         .map((item) => {
-            if (!item || item === '*') {
+            if (item !== 0 && (!item || item === '*')) {
                 return xMin;
             }
             return Number(item);

--- a/small-multiple-column-group/parseData.js
+++ b/small-multiple-column-group/parseData.js
@@ -60,7 +60,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
             .map((item) => {
-                if (!item || item === '*') {
+                if (item !== 0 && (!item || item === '*')) {
                     return yMin;
                 }
                 return Number(item);

--- a/small-multiple-column-timeline/parseData.js
+++ b/small-multiple-column-timeline/parseData.js
@@ -83,7 +83,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
         .map((item) => {
-            if (!item || item === '*') {
+            if (item !== 0 && (!item || item === '*')) {
                 return yMin;
             }
             return Number(item);

--- a/small-multiple-line/parseData.js
+++ b/small-multiple-line/parseData.js
@@ -79,7 +79,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
         .map((item) => {
-            if (!item || item === '*') {
+            if (item !== 0 && (!item || item === '*')) {
                 return yMin;
             }
             return Number(item);

--- a/small-multiple-multi-line/parseData.js
+++ b/small-multiple-multi-line/parseData.js
@@ -110,7 +110,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
             .map((item) => {
-                if (!item || item === '*') {
+                if (item !== 0 && (!item || item === '*')) {
                     return yMin;
                 }
                 return Number(item);

--- a/sterling-predictor/parseData.js
+++ b/sterling-predictor/parseData.js
@@ -276,7 +276,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
         .map((item) => {
-            if (!item || item === '*') {
+            if (item !== 0 && (!item || item === '*')) {
                 return yMin;
             }
             return Number(item);

--- a/treemap/parseData.js
+++ b/treemap/parseData.js
@@ -60,7 +60,7 @@ export function extentMulti(d, columns, yMin) {
     const ext = d.reduce((acc, row) => {
         const values = columns.map(key => row[key])
             .map((item) => {
-                if (!item || item === '*') {
+                if (item !== 0 && (!item || item === '*')) {
                     return yMin;
                 }
                 return Number(item);


### PR DESCRIPTION
Without checking for 0 first, any data points with a 0 as a value were automatically pulling in the yMin in the chart template config.